### PR TITLE
Identify spark pod with label spark-app-selector

### DIFF
--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -150,7 +150,7 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			Namespace: "default",
 			UID:       "UID-POD-00001",
 			Labels: map[string]string{
-				"spark-app-id": "spark-0001",
+				"spark-app-selector": "spark-0001",
 				"queue":        "root.a",
 			},
 		},

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -32,7 +32,7 @@ const Memory = "memory"
 const CPU = "vcore"
 
 // Spark
-const SparkLabelAppID = "spark-app-id"
+const SparkLabelAppID = "spark-app-selector"
 const SparkLabelRole = "spark-role"
 const SparkLabelRoleDriver = "driver"
 

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -142,6 +142,8 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent) {
 		defer atomic.AddInt32(&asyncDispatchCount, -1)
 		for p.isRunning() {
 			select {
+			case <- p.stopChan:
+				return
 			case p.eventChan <- event:
 				return
 			case <-time.After(AsyncDispatchCheckInterval):

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -250,7 +250,7 @@ func TestDispatchTimeout(t *testing.T) {
 	// wait until async dispatch routine times out
 	if err := utils.WaitForCondition(func() bool {
 		return atomic.LoadInt32(&asyncDispatchCount) == int32(0)
-	}, 100 * time.Millisecond, 3 * time.Second); err != nil {
+	}, 100 * time.Millisecond, DispatchTimeout+AsyncDispatchCheckInterval); err != nil {
 		t.Fatalf(err.Error())
 	}
 

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -195,6 +195,8 @@ func TestDispatchTimeout(t *testing.T) {
 	AsyncDispatchCheckInterval = 100 * time.Millisecond
 	DispatchTimeout = 500 * time.Millisecond
 	defer func() {
+		dispatcher.lock.Lock()
+		defer dispatcher.lock.Unlock()
 		dispatcher.eventChan = make(chan events.SchedulingEvent, backupCapacity)
 		AsyncDispatchCheckInterval = backupAsyncDispatchCheckInterval
 		DispatchTimeout = backupDispatchTimeout

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -240,22 +240,12 @@ func TestDispatchTimeout(t *testing.T) {
 	// 2nd one should be added to the channel
 	// 3rd one should be posted as an async request
 	time.Sleep(100 * time.Millisecond)
-
-	// depends on the timing, async count might be 1 or 2
 	assert.Equal(t, atomic.LoadInt32(&asyncDispatchCount), int32(1))
 
 	// verify Dispatcher#asyncDispatch is called
 	buf := make([]byte, 1<<16)
 	runtime.Stack(buf, true)
 	assert.Assert(t, strings.Contains(string(buf), "asyncDispatch"))
-
-	// notify the the handler
-	for _, ev := range []TestAppEvent {event0, event1, event2} {
-		select {
-		case ev.flag <- true:
-		default:
-		}
-	}
 
 	// wait until async dispatch routine times out
 	if err := utils.WaitForCondition(func() bool {

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -195,8 +195,6 @@ func TestDispatchTimeout(t *testing.T) {
 	AsyncDispatchCheckInterval = 100 * time.Millisecond
 	DispatchTimeout = 500 * time.Millisecond
 	defer func() {
-		dispatcher.lock.Lock()
-		defer dispatcher.lock.Unlock()
 		dispatcher.eventChan = make(chan events.SchedulingEvent, backupCapacity)
 		AsyncDispatchCheckInterval = backupAsyncDispatchCheckInterval
 		DispatchTimeout = backupDispatchTimeout


### PR DESCRIPTION
Native spark on K8s adds a label "spark-app-selector" to track spark app ID. We should directly read from this label.