### PR TITLE
Order imports and format issues from operator changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters-settings:
   gofmt:
     simplify: true
   goimports:
-    local-prefixes: github.com/cloudera/yunikorn
+    local-prefixes: github.com/apache/incubator-yunikorn
   govet:
     check-shadowing: true
   depguard:

--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -19,13 +19,13 @@
 package appmgmt
 
 import (
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"go.uber.org/zap"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/general"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/sparkoperator"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 )
 
@@ -40,9 +40,9 @@ type AppManagementService struct {
 func NewAMService(amProtocol interfaces.ApplicationManagementProtocol,
 	apiProvider client.APIProvider) *AppManagementService {
 	appManager := &AppManagementService{
-		amProtocol:    amProtocol,
-		apiProvider:   apiProvider,
-		managers:      make([]interfaces.AppManager, 0),
+		amProtocol:  amProtocol,
+		apiProvider: apiProvider,
+		managers:    make([]interfaces.AppManager, 0),
 	}
 
 	if !apiProvider.IsTestingMode() {
@@ -96,7 +96,7 @@ func (svc *AppManagementService) Start() error {
 		log.Logger.Info("service started",
 			zap.String("serviceName", optService.Name()))
 	}
-	
+
 	return nil
 }
 

--- a/pkg/appmgmt/appmgmt_recovery.go
+++ b/pkg/appmgmt/appmgmt_recovery.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
-	"go.uber.org/zap"
 )
 
 func (svc *AppManagementService) WaitForRecovery(maxTimeout time.Duration) error {
@@ -59,7 +60,7 @@ func (svc *AppManagementService) recoverApps() (map[string]interfaces.ManagedApp
 						Metadata: appMeta,
 						Recovery: true,
 					}); app != nil {
-						recoveringApps[app.GetApplicationID()] = app
+					recoveringApps[app.GetApplicationID()] = app
 				}
 			}
 		}

--- a/pkg/appmgmt/appmgmt_recovery_test.go
+++ b/pkg/appmgmt/appmgmt_recovery_test.go
@@ -22,14 +22,15 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/assert"
+	v1 "k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"gotest.tools/assert"
-	v1 "k8s.io/api/core/v1"
 )
 
 func TestAppManagerRecoveryState(t *testing.T) {
@@ -88,13 +89,11 @@ func TestAppManagerRecoveryExitCondition(t *testing.T) {
 }
 
 type mockedAppManager struct {
-
 }
 
 func (ma *mockedAppManager) Name() string {
 	return "mocked-app-manager"
 }
-
 
 func (ma *mockedAppManager) ServiceInit() error {
 	return nil

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -19,17 +19,18 @@
 package general
 
 import (
+	"go.uber.org/zap"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	k8sCache "k8s.io/client-go/tools/cache"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
-	k8sCache "k8s.io/client-go/tools/cache"
 )
 
 // implements interfaces#Recoverable, interfaces#AppManager

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -21,12 +21,13 @@ package general
 import (
 	"testing"
 
+	"gotest.tools/assert"
+	"k8s.io/api/core/v1"
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
-	"gotest.tools/assert"
-	v1 "k8s.io/api/core/v1"
-	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetAppMetadata(t *testing.T) {

--- a/pkg/appmgmt/interfaces/recoverable.go
+++ b/pkg/appmgmt/interfaces/recoverable.go
@@ -19,8 +19,9 @@
 package interfaces
 
 import (
+	"k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	v1 "k8s.io/api/core/v1"
 )
 
 // recoverable interface defines a certain type of app that can be recovered upon scheduler' restart

--- a/pkg/appmgmt/sparkoperator/spark.go
+++ b/pkg/appmgmt/sparkoperator/spark.go
@@ -22,16 +22,17 @@ import (
 	"github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/apis/sparkoperator.k8s.io/v1beta2"
 	crcClientSet "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/clientset/versioned"
 	crInformers "github.com/GoogleCloudPlatform/spark-on-k8s-operator/pkg/client/informers/externalversions"
+	"go.uber.org/zap"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sCache "k8s.io/client-go/tools/cache"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	k8sCache "k8s.io/client-go/tools/cache"
 )
 
 const (

--- a/pkg/cache/amprotocol_mock.go
+++ b/pkg/cache/amprotocol_mock.go
@@ -97,7 +97,7 @@ func (m *MockedAMProtocol) RemoveTask(appID, taskID string) error {
 }
 
 func (m *MockedAMProtocol) NotifyApplicationComplete(appID string) {
-	if app := m.GetApplication(appID); app != nil{
+	if app := m.GetApplication(appID); app != nil {
 		if p, valid := app.(*Application); valid {
 			p.SetState(events.States().Application.Completed)
 		}

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/looplab/fsm"
 	"go.uber.org/zap"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/api"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -153,7 +153,7 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			UID:       "UID-POD-00001",
 			Labels: map[string]string{
 				"spark-app-selector": "spark-0001",
-				"queue":        "root.a",
+				"queue":              "root.a",
 			},
 		},
 		Spec:   v1.PodSpec{},

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -22,21 +22,20 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	schedulercache "github.com/apache/incubator-yunikorn-k8shim/pkg/cache/external"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	plugin "github.com/apache/incubator-yunikorn-k8shim/pkg/plugin/predicates"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-
-	"k8s.io/client-go/tools/cache"
 )
 
 // context maintains scheduling state, like apps and apps' tasks.
@@ -586,4 +585,3 @@ func (ctx *Context) SchedulerNodeEventHandler() func(obj interface{}) {
 	// this is not required in some tests
 	return nil
 }
-

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -22,6 +22,11 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
@@ -29,10 +34,6 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/dispatcher"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 func (ctx *Context) WaitForRecovery(recoverableAppManagers []interfaces.Recoverable, maxTimeout time.Duration) error {

--- a/pkg/cache/context_recovery_test.go
+++ b/pkg/cache/context_recovery_test.go
@@ -22,12 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"gotest.tools/assert"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -21,12 +21,13 @@ package cache
 import (
 	"testing"
 
+	"gotest.tools/assert"
+	"k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
-	"gotest.tools/assert"
-	"k8s.io/api/core/v1"
 )
 
 const fakeClusterID = "test-cluster"
@@ -204,7 +205,7 @@ func TestAddTask(t *testing.T) {
 	assert.Equal(t, task.GetTaskID(), "task00002")
 
 	// add a task with dup taskID
-	task  = context.AddTask(&interfaces.AddTaskRequest{
+	task = context.AddTask(&interfaces.AddTaskRequest{
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: "app00001",
 			TaskID:        "task00002",

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -47,15 +47,15 @@ type SchedulerCache struct {
 	assumedPods map[string]bool
 	lock        sync.RWMutex
 	// client APIs
-	clients     *client.Clients
+	clients *client.Clients
 }
 
 func NewSchedulerCache(clients *client.Clients) *SchedulerCache {
 	cache := &SchedulerCache{
-		nodesMap:      make(map[string]*schedulernode.NodeInfo),
-		podsMap:       make(map[string]*v1.Pod),
-		assumedPods:   make(map[string]bool),
-		clients:       clients,
+		nodesMap:    make(map[string]*schedulernode.NodeInfo),
+		podsMap:     make(map[string]*v1.Pod),
+		assumedPods: make(map[string]bool),
+		clients:     clients,
 	}
 	cache.assignArgs(GetPluginArgs())
 	return cache

--- a/pkg/cache/nodes_test.go
+++ b/pkg/cache/nodes_test.go
@@ -22,11 +22,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"gotest.tools/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache/external"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -211,7 +211,7 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 	// core and shim to negotiate on when to set the state to unscheduable and trigger the
 	// auto-scaling appropriately.
 	go func(t *Task) {
-		time.Sleep(5*time.Second)
+		time.Sleep(5 * time.Second)
 		if t.GetTaskState() == events.States().Task.Scheduling {
 			log.Logger.Debug("updating pod state ",
 				zap.String("appID", t.applicationID),

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -22,11 +22,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/incubator-yunikorn-core/pkg/api"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/api"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 )
 
 type Type int
@@ -42,7 +43,7 @@ const (
 
 type APIProvider interface {
 	GetAPIs() *Clients
-	AddEventHandler (handlers *ResourceEventHandlers)
+	AddEventHandler(handlers *ResourceEventHandlers)
 	Start()
 	Stop()
 	WaitForSync() error
@@ -54,7 +55,7 @@ type APIProvider interface {
 type ResourceEventHandlers struct {
 	Type
 	FilterFn func(obj interface{}) bool
-	AddFn func(obj interface{})
+	AddFn    func(obj interface{})
 	UpdateFn func(old, new interface{})
 	DeleteFn func(obj interface{})
 }
@@ -172,7 +173,7 @@ func (s *APIFactory) WaitForSync() error {
 		// skip this in test mode
 		return nil
 	}
-	return s.clients.WaitForSync(time.Second, 30 * time.Second)
+	return s.clients.WaitForSync(time.Second, 30*time.Second)
 }
 
 func (s *APIFactory) Start() {

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -19,12 +19,13 @@
 package client
 
 import (
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	corev1 "k8s.io/client-go/listers/core/v1"
 	storagev1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 )
 
 type MockedAPIProvider struct {
@@ -34,7 +35,7 @@ type MockedAPIProvider struct {
 func NewMockedAPIProvider() *MockedAPIProvider {
 	return &MockedAPIProvider{
 		clients: &Clients{
-			Conf:              &conf.SchedulerConf{
+			Conf: &conf.SchedulerConf{
 				ClusterID:            "yk-test-cluster",
 				ClusterVersion:       "0.1",
 				SchedulerName:        "yunikorn",
@@ -77,7 +78,7 @@ func (m *MockedAPIProvider) MockDeleteFn(dfn func(pod *v1.Pod) error) {
 	}
 }
 
-func (m *MockedAPIProvider) SetNodeLister(lister corev1.NodeLister)  {
+func (m *MockedAPIProvider) SetNodeLister(lister corev1.NodeLister) {
 	informer := m.clients.NodeInformer
 	if i, ok := informer.(*test.MockedNodeInformer); ok {
 		i.SetLister(lister)
@@ -92,7 +93,7 @@ func (m *MockedAPIProvider) IsTestingMode() bool {
 	return true
 }
 
-func (m *MockedAPIProvider) AddEventHandler (handlers *ResourceEventHandlers) {
+func (m *MockedAPIProvider) AddEventHandler(handlers *ResourceEventHandlers) {
 	// no impl
 }
 
@@ -109,7 +110,7 @@ func (m *MockedAPIProvider) WaitForSync() error {
 }
 
 // MockedPersistentVolumeInformer implements PersistentVolumeInformer interface
-type MockedPersistentVolumeInformer struct {}
+type MockedPersistentVolumeInformer struct{}
 
 func (m *MockedPersistentVolumeInformer) Informer() cache.SharedIndexInformer {
 	return nil
@@ -120,7 +121,7 @@ func (m *MockedPersistentVolumeInformer) Lister() corev1.PersistentVolumeLister 
 }
 
 // MockedPersistentVolumeClaimInformer implements PersistentVolumeClaimInformer interface
-type MockedPersistentVolumeClaimInformer struct {}
+type MockedPersistentVolumeClaimInformer struct{}
 
 func (m *MockedPersistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {
 	return nil
@@ -131,7 +132,7 @@ func (m *MockedPersistentVolumeClaimInformer) Lister() corev1.PersistentVolumeCl
 }
 
 // MockedStorageClassInformer implements StorageClassInformer interface
-type MockedStorageClassInformer struct {}
+type MockedStorageClassInformer struct{}
 
 func (m *MockedStorageClassInformer) Informer() cache.SharedIndexInformer {
 	return nil

--- a/pkg/client/clients.go
+++ b/pkg/client/clients.go
@@ -21,13 +21,14 @@ package client
 import (
 	"time"
 
-	"github.com/apache/incubator-yunikorn-core/pkg/api"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"k8s.io/client-go/informers"
 	coreInformerV1 "k8s.io/client-go/informers/core/v1"
 	storageInformerV1 "k8s.io/client-go/informers/storage/v1"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/api"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 )
 
 // clients encapsulates a set of useful client APIs
@@ -42,7 +43,7 @@ type Clients struct {
 	SchedulerAPI api.SchedulerAPI
 
 	// informer factory
-	InformerFactory   informers.SharedInformerFactory
+	InformerFactory informers.SharedInformerFactory
 
 	// resource informers
 	PodInformer       coreInformerV1.PodInformer

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -19,11 +19,12 @@
 package client
 
 import (
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"go.uber.org/zap"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 )
 
 // fake client allows us to inject customized bind/delete pod functions

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -159,9 +159,9 @@ func CreateUpdateRequestForNewNode(node Node) si.UpdateRequest {
 func CreateUpdateRequestForUpdatedNode(node Node) si.UpdateRequest {
 	// Currently only includes resource in the update request
 	nodeInfo := &si.UpdateNodeInfo{
-		NodeID:               node.name,
-		Attributes:           make(map[string]string),
-		SchedulableResource:  node.resource,
+		NodeID:              node.name,
+		Attributes:          make(map[string]string),
+		SchedulableResource: node.resource,
 	}
 
 	nodes := make([]*si.UpdateNodeInfo, 1)

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -238,7 +238,7 @@ func TestNodeResource(t *testing.T) {
 	nodeCapacity := make(map[v1.ResourceName]resource.Quantity)
 	nodeCapacity[v1.ResourceCPU] = resource.MustParse("14500m")
 	result := GetNodeResource(&v1.NodeStatus{
-		Capacity:        nodeCapacity,
+		Capacity: nodeCapacity,
 	})
 
 	assert.Equal(t, result.Resources[CPU].GetValue(), int64(14500))

--- a/pkg/common/test/nodeinformer_mock.go
+++ b/pkg/common/test/nodeinformer_mock.go
@@ -19,7 +19,7 @@
 package test
 
 import (
-	v1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -44,4 +44,3 @@ func (m *MockedNodeInformer) Lister() v1.NodeLister {
 func (m *MockedNodeInformer) SetLister(lister v1.NodeLister) {
 	m.nodeLister = lister
 }
-

--- a/pkg/common/test/recoverable_apps_mock.go
+++ b/pkg/common/test/recoverable_apps_mock.go
@@ -19,10 +19,11 @@
 package test
 
 import (
+	"k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	v1 "k8s.io/api/core/v1"
 )
 
 type MockedRecoverableAppManager struct {

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -144,7 +144,7 @@ func (p *Dispatcher) asyncDispatch(event events.SchedulingEvent) {
 		defer atomic.AddInt32(&asyncDispatchCount, -1)
 		for p.isRunning() {
 			select {
-			case <- stop:
+			case <-stop:
 				return
 			case p.eventChan <- event:
 				return

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/assert"
+
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
-	"gotest.tools/assert"
 )
 
 // app event for testing
@@ -204,11 +205,11 @@ func TestDispatchTimeout(t *testing.T) {
 		DispatchTimeout = backupDispatchTimeout
 	}()
 
-    // start the handler, but waiting on a flag
+	// start the handler, but waiting on a flag
 	RegisterEventHandler(EventTypeApp, func(obj interface{}) {
 		if appEvent, ok := obj.(TestAppEvent); ok {
 			fmt.Println(fmt.Sprintf("handling %s", appEvent.appID))
-			<- appEvent.flag
+			<-appEvent.flag
 			fmt.Println(fmt.Sprintf("handling %s DONE", appEvent.appID))
 		}
 	})
@@ -240,7 +241,7 @@ func TestDispatchTimeout(t *testing.T) {
 	// wait until async dispatch routine times out
 	if err := utils.WaitForCondition(func() bool {
 		return atomic.LoadInt32(&asyncDispatchCount) == int32(0)
-	}, 100 * time.Millisecond, DispatchTimeout+AsyncDispatchCheckInterval); err != nil {
+	}, 100*time.Millisecond, DispatchTimeout+AsyncDispatchCheckInterval); err != nil {
 		t.Fatalf(err.Error())
 	}
 

--- a/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/mutating_controller.go
@@ -131,7 +131,7 @@ func updateLabels(pod *v1.Pod, patch []patchOperation) []patchOperation {
 			if pod.Namespace != "" {
 				podNamespace = pod.Namespace
 			}
- 			generatedID := fmt.Sprintf("%s_%s_%d", podNamespace, pod.Name, time.Now().Unix())
+			generatedID := fmt.Sprintf("%s_%s_%d", podNamespace, pod.Name, time.Now().Unix())
 			log.Logger.Debug("adding application ID",
 				zap.String("generatedID", generatedID))
 			result[common.LabelApplicationID] = generatedID

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -22,16 +22,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/looplab/fsm"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/api"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/callback"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/dispatcher"
@@ -97,7 +97,7 @@ func newShimSchedulerInternal(ctx *cache.Context, apiFactory client.APIProvider,
 		fsm.Callbacks{
 			string(events.RegisterScheduler):       ss.register(),                      // trigger registration
 			string(events.RegisterSchedulerFailed): ss.handleSchedulerFailure(),        // registration failed, stop the scheduler
-			string(events.RecoverSchedulerFailed):  ss.handleSchedulerFailure(),                          // recovery failed
+			string(events.RecoverSchedulerFailed):  ss.handleSchedulerFailure(),        // recovery failed
 			string(states.Registered):              ss.triggerSchedulerStateRecovery(), // if reaches registered, trigger recovering
 			string(states.Recovering):              ss.recoverSchedulerState(),         // do recovering
 			string(states.Running):                 ss.doScheduling(),                  // do scheduling

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -23,6 +23,11 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"gotest.tools/assert"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/apache/incubator-yunikorn-core/pkg/api"
 	coreconfigs "github.com/apache/incubator-yunikorn-core/pkg/common/configs"
 	"github.com/apache/incubator-yunikorn-core/pkg/entrypoint"
@@ -36,10 +41,6 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
-	"gotest.tools/assert"
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // fake cluster is used for testing
@@ -99,7 +100,7 @@ func (fc *MockScheduler) addTask(appID string, taskID string, ask *si.Resource) 
 		Metadata: interfaces.TaskMetadata{
 			ApplicationID: appID,
 			TaskID:        taskID,
-			Pod:           &v1.Pod{
+			Pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: taskID,
 				},
@@ -156,7 +157,7 @@ func (fc *MockScheduler) addApplication(appId string, queue string) {
 			User:          "test-user",
 			Tags:          map[string]string{"app-type": "test-app"},
 		},
-		Recovery:      false,
+		Recovery: false,
 	})
 }
 

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"gotest.tools/assert"
+	"k8s.io/api/core/v1"
+
 	"github.com/apache/incubator-yunikorn-core/pkg/api"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
@@ -32,9 +36,6 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/test"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-	"go.uber.org/zap"
-	"gotest.tools/assert"
-	"k8s.io/api/core/v1"
 )
 
 func TestApplicationScheduling(t *testing.T) {
@@ -219,7 +220,7 @@ partitions:
 		AddResource(common.Memory, 50).
 		AddResource(common.CPU, 5).
 		Build()
-	cluster.addTask("app0001", "task0001", taskResource, )
+	cluster.addTask("app0001", "task0001", taskResource)
 	cluster.addTask("app0001", "task0002", taskResource)
 
 	// wait for scheduling app and tasks


### PR DESCRIPTION
In PR #72 goimports had not been run over the code.
The linter check also is still pointing to the old path for the repo