### PR TITLE
[YUNIKORN-32] YuniKorn should respect reserved resources on Kubelet.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20200212043150-3df703098970
-	github.com/apache/incubator-yunikorn-core v0.0.0-20200305002428-995de5888097
+	github.com/apache/incubator-yunikorn-core v0.0.0-20200312021020-9186877b0ef9
 	github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200205180409-ebed5aec1d1f
 	github.com/coreos/bbolt v1.3.3 // indirect
 	github.com/coreos/etcd v3.3.13+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/apache/incubator-yunikorn-core v0.0.0-20200220000753-366b635676e8 h1:
 github.com/apache/incubator-yunikorn-core v0.0.0-20200220000753-366b635676e8/go.mod h1:qaaM/20rGS+ymrSBWUzKoisjr1U+AseLwp2Aqzt9dbQ=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200305002428-995de5888097 h1:4n8DQE1UeyOxYSG+kpsKzwLAB9s35k/ynypj/c/PlnU=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200305002428-995de5888097/go.mod h1:qaaM/20rGS+ymrSBWUzKoisjr1U+AseLwp2Aqzt9dbQ=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200312021020-9186877b0ef9 h1:AvihfK3rrs+QLzWqqkbDSVVcPS9KNJ4sX9QIjXXNCzg=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200312021020-9186877b0ef9/go.mod h1:qJhs+ERlZUmv2VDuyQV+jjDiZhwr6LJiomWE1NTiJ2w=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200205180409-ebed5aec1d1f h1:rgrw1i7KqVnIVS53mYYS+M70hBY6QVk1USn4NjKhw7k=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200205180409-ebed5aec1d1f/go.mod h1:De+73NNH4KaRL9MGGnCyHJOtx2oQGVYOaespfoRNGSo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/cache/nodes_test.go
+++ b/pkg/cache/nodes_test.go
@@ -80,7 +80,7 @@ func TestAddNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 	}
 
@@ -144,7 +144,7 @@ func TestUpdateNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 	}
 
@@ -155,7 +155,7 @@ func TestUpdateNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 	}
 
@@ -183,7 +183,7 @@ func TestUpdateNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: newResourceList,
+			Allocatable: newResourceList,
 		},
 	}
 
@@ -258,7 +258,7 @@ func TestDeleteNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 	}
 
@@ -326,7 +326,7 @@ func TestCordonNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: false,
@@ -340,7 +340,7 @@ func TestCordonNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: true,
@@ -368,7 +368,7 @@ func TestCordonNode(t *testing.T) {
 			UID:       "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: false,

--- a/pkg/common/node_test.go
+++ b/pkg/common/node_test.go
@@ -41,16 +41,20 @@ func TestCreateNodeFromSpec(t *testing.T) {
 }
 
 func TestCreateNode(t *testing.T) {
-	resourceList := make(map[v1.ResourceName]resource.Quantity)
-	resourceList[v1.ResourceName("memory")] = *resource.NewQuantity(999*1000*1000, resource.DecimalSI)
-	resourceList[v1.ResourceName("cpu")] = *resource.NewQuantity(9, resource.DecimalSI)
+	capacityList := make(map[v1.ResourceName]resource.Quantity)
+	capacityList[v1.ResourceName("memory")] = *resource.NewQuantity(999*1000*1000, resource.DecimalSI)
+	capacityList[v1.ResourceName("cpu")] = *resource.NewQuantity(9, resource.DecimalSI)
+	allocatableList := make(map[v1.ResourceName]resource.Quantity)
+	allocatableList[v1.ResourceName("memory")] = *resource.NewQuantity(999*1000*1000, resource.DecimalSI)
+	allocatableList[v1.ResourceName("cpu")] = *resource.NewQuantity(8, resource.DecimalSI)
 	var k8sNode = v1.Node{
 		ObjectMeta: apis.ObjectMeta{
 			Name: "host0001",
 			UID:  "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Capacity:    capacityList,
+			Allocatable: allocatableList,
 		},
 	}
 	node := CreateFrom(&k8sNode)
@@ -58,7 +62,7 @@ func TestCreateNode(t *testing.T) {
 	assert.Equal(t, node.uid, "uid_0001")
 	assert.Equal(t, len(node.resource.Resources), 2)
 	assert.Equal(t, node.resource.Resources[Memory].Value, int64(999))
-	assert.Equal(t, node.resource.Resources[CPU].Value, int64(9000))
+	assert.Equal(t, node.resource.Resources[CPU].Value, int64(8000))
 }
 
 func TestCreateNodeWithCustomResource(t *testing.T) {
@@ -72,7 +76,7 @@ func TestCreateNodeWithCustomResource(t *testing.T) {
 			UID:  "uid_0001",
 		},
 		Status: v1.NodeStatus{
-			Capacity: resourceList,
+			Allocatable: resourceList,
 		},
 	}
 	node := CreateFrom(&k8sNode)

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -74,7 +74,12 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 }
 
 func GetNodeResource(nodeStatus *v1.NodeStatus) *si.Resource {
-	return getResource(nodeStatus.Capacity)
+	// Capacity represents the total capacity of the node
+	// Allocatable represents the resources of a node that are available for scheduling.
+	// Each kubelet can reserve some resources from the scheduler.
+	// We can rely on Allocatable resource here, because if it is not specified,
+	// the default value is same as Capacity. (same behavior as the default-scheduler)
+	return getResource(nodeStatus.Allocatable)
 }
 
 func getResource(resourceList v1.ResourceList) *si.Resource {

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -238,7 +238,7 @@ func TestNodeResource(t *testing.T) {
 	nodeCapacity := make(map[v1.ResourceName]resource.Quantity)
 	nodeCapacity[v1.ResourceCPU] = resource.MustParse("14500m")
 	result := GetNodeResource(&v1.NodeStatus{
-		Capacity: nodeCapacity,
+		Allocatable: nodeCapacity,
 	})
 
 	assert.Equal(t, result.Resources[CPU].GetValue(), int64(14500))


### PR DESCRIPTION
Kubelet can reserve some resources from scheduling, we should respect that. Otherwise, we might be running into race-conditions. Ie. yunikorn thinks there is enough resources on the node, but actually there isn't.

