### PR TITLE
[YUNIKORN-54] admission-controller should keep generated ID tight

### DIFF
--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -138,25 +138,7 @@ func updateLabels(pod *v1.Pod, patch []patchOperation) []patchOperation {
 
 	if _, ok := existingLabels[common.SparkLabelAppID]; !ok {
 		if _, ok := existingLabels[common.LabelApplicationID]; !ok {
-			// if app id not exist, generate one
-			// the generated ID is using [PodNamespace]_[PodName]_[Timestamp] naming convention.
-			// some admission controllers have strict checks of the length/format of each labels,
-			// this convention keeps the name tidy and short.
-			podNamespace := "default"
-			if pod.Namespace != "" {
-				podNamespace = pod.Namespace
-			}
-
-			// pod's name can be generated, if name is not explicitly specified
-			// look for generateName instead
-			podName := "unknown"
-			if pod.Name != "" {
-				podName = pod.Name
-			} else if pod.GenerateName != "" {
-				podName = pod.GenerateName
-			}
-
-			generatedID := fmt.Sprintf("%s_%s_%d", podNamespace, podName, time.Now().Unix())
+			generatedID := fmt.Sprintf("__app_%d", time.Now().UnixNano())
 			log.Logger.Debug("adding application ID",
 				zap.String("generatedID", generatedID))
 			result[common.LabelApplicationID] = generatedID

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -138,7 +138,25 @@ func updateLabels(pod *v1.Pod, patch []patchOperation) []patchOperation {
 
 	if _, ok := existingLabels[common.SparkLabelAppID]; !ok {
 		if _, ok := existingLabels[common.LabelApplicationID]; !ok {
-			generatedID := fmt.Sprintf("__app_%d", time.Now().UnixNano())
+			// if app id not exist, generate one
+			// the generated ID is using [PodNamespace]_[PodName]_[Timestamp] naming convention.
+			// some admission controllers have strict checks of the length/format of each labels,
+			// this convention keeps the name tidy and short.
+			podNamespace := "default"
+			if pod.Namespace != "" {
+				podNamespace = pod.Namespace
+			}
+
+			// pod's name can be generated, if name is not explicitly specified
+			// look for generateName instead
+			podName := "unknown"
+			if pod.Name != "" {
+				podName = pod.Name
+			} else if pod.GenerateName != "" {
+				podName = pod.GenerateName
+			}
+
+			generatedID := fmt.Sprintf("%s_%s_%d", podNamespace, podName, time.Now().Unix())
 			log.Logger.Debug("adding application ID",
 				zap.String("generatedID", generatedID))
 			result[common.LabelApplicationID] = generatedID

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -63,7 +63,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -137,7 +137,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.abc")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -168,7 +168,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -196,7 +196,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_some-pod-"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -63,7 +63,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -137,7 +137,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.abc")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -168,7 +168,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}
@@ -196,7 +196,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "default_some-pod-"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "__app_"), true)
 	} else {
 		t.Fatal("patch info is not expected")
 	}


### PR DESCRIPTION
Simple change. We need a better format of generated appIDs. 
And I have filed https://issues.apache.org/jira/browse/YUNIKORN-55 to re-add that info back to allocation asks (instead of having them in the app ID).