### PR TITLE
[YUNIKORN-76] YuniKorn admission-controller should be installed on the same host as Yunikorn-scheduler

### DIFF
--- a/deployments/admission-controllers/scheduler/templates/server.yaml.template
+++ b/deployments/admission-controllers/scheduler/templates/server.yaml.template
@@ -15,6 +15,16 @@ spec:
       labels:
         app: yunikorn
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: component
+                  operator: In
+                  values:
+                  - scheduler
+              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: yunikorn-admission-controller-webhook
           image: yunikorn/yunikorn-scheduler-admission-controller:latest

--- a/deployments/scheduler/scheduler-load.yaml
+++ b/deployments/scheduler/scheduler-load.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         app: yunikorn
+        component: scheduler
       name: yunikorn-scheduler
     spec:
       containers:

--- a/deployments/scheduler/scheduler.yaml
+++ b/deployments/scheduler/scheduler.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       labels:
         app: yunikorn
+        component: scheduler
       name: yunikorn-scheduler
     spec:
       hostNetwork: true

--- a/helm-charts/yunikorn/templates/deployment.yaml
+++ b/helm-charts/yunikorn/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       name: yunikorn-scheduler
       labels:
         app: yunikorn
+        component: scheduler
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount }}


### PR DESCRIPTION

Tested with the following steps:
- created a multi node cluster locally with Vagrant
- changed the image pull policy to Never in Helm chart
- built the image locally and made a tar.gz
- uploaded the tar.gz with the images to the hosts and load the images
- checked if the two pod were scheduled on the same node each time.