### PR TITLE
[YUNIKORN-25] Logging improvements

### DIFF
--- a/pkg/appmgmt/appmgmt.go
+++ b/pkg/appmgmt/appmgmt.go
@@ -93,7 +93,7 @@ func (svc *AppManagementService) Start() error {
 			return err
 		}
 
-		log.Logger.Info("service started",
+		log.Logger.Info("app management service started",
 			zap.String("serviceName", optService.Name()))
 	}
 

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -103,6 +103,8 @@ func NewApplication(appID, queueName, user string, tags map[string]string, sched
 			string(events.RecoverApplication):  app.handleRecoverApplicationEvent,
 			string(events.RejectApplication):   app.handleRejectApplicationEvent,
 			string(events.CompleteApplication): app.handleCompleteApplicationEvent,
+			events.EnterState:                  app.enterState,
+
 		},
 	)
 
@@ -348,4 +350,11 @@ func (app *Application) handleRejectApplicationEvent(event *fsm.Event) {
 
 func (app *Application) handleCompleteApplicationEvent(event *fsm.Event) {
 	// TODO app lifecycle updates
+}
+
+func (app *Application) enterState(event *fsm.Event) {
+	log.Logger.Info("app state",
+		zap.String("appID", app.applicationID),
+		zap.String("queue", app.queue),
+		zap.String("state", app.GetApplicationState()))
 }

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -104,7 +104,6 @@ func NewApplication(appID, queueName, user string, tags map[string]string, sched
 			string(events.RejectApplication):   app.handleRejectApplicationEvent,
 			string(events.CompleteApplication): app.handleCompleteApplicationEvent,
 			events.EnterState:                  app.enterState,
-
 		},
 	)
 

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -112,15 +112,15 @@ func (ctx *Context) addNode(obj interface{}) {
 	}
 
 	// add node to secondary scheduler cache
-	log.Logger.Info("adding node to cache", zap.String("NodeName", node.Name))
+	log.Logger.Debug("adding node to cache", zap.String("NodeName", node.Name))
 	ctx.schedulerCache.AddNode(node)
 
 	// add node to internal cache
 	ctx.nodes.addNode(node)
 
 	// post the event
-	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "Accepted",
-		"node is accepted by the scheduler")
+	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "NodeAccepted",
+		fmt.Sprintf("node %s is accepted by the scheduler", node.Name))
 }
 
 func (ctx *Context) updateNode(oldObj, newObj interface{}) {
@@ -140,8 +140,6 @@ func (ctx *Context) updateNode(oldObj, newObj interface{}) {
 	}
 
 	// update secondary cache
-	log.Logger.Debug("updating node in cache",
-		zap.String("OldNodeName", oldNode.Name))
 	if err := ctx.schedulerCache.UpdateNode(oldNode, newNode); err != nil {
 		log.Logger.Error("unable to update node in scheduler cache",
 			zap.Error(err))
@@ -171,8 +169,8 @@ func (ctx *Context) deleteNode(obj interface{}) {
 	ctx.nodes.deleteNode(node)
 
 	// post the event
-	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "Deleted",
-		"node is deleted from the scheduler")
+	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "NodeDeleted",
+		fmt.Sprintf("node %s is deleted from the scheduler", node.Name))
 }
 
 func (ctx *Context) addPodToCache(obj interface{}) {
@@ -182,7 +180,7 @@ func (ctx *Context) addPodToCache(obj interface{}) {
 		return
 	}
 
-	log.Logger.Info("adding pod to cache", zap.String("podName", pod.Name))
+	log.Logger.Debug("adding pod to cache", zap.String("podName", pod.Name))
 	if err := ctx.schedulerCache.AddPod(pod); err != nil {
 		log.Logger.Error("add pod to scheduler cache failed",
 			zap.String("podName", pod.Name),
@@ -207,7 +205,7 @@ func (ctx *Context) removePodFromCache(obj interface{}) {
 		return
 	}
 
-	log.Logger.Info("removing pod from cache", zap.String("podName", pod.Name))
+	log.Logger.Debug("removing pod from cache", zap.String("podName", pod.Name))
 	if err := ctx.schedulerCache.RemovePod(pod); err != nil {
 		log.Logger.Error("failed to remove pod from scheduler cache",
 			zap.String("podName", pod.Name),
@@ -486,7 +484,10 @@ func (ctx *Context) RemoveApplication(appID string) error {
 
 // this implements ApplicationManagementProtocol
 func (ctx *Context) AddTask(request *interfaces.AddTaskRequest) interfaces.ManagedTask {
-	log.Logger.Debug("AddTask", zap.Any("Request", request))
+	log.Logger.Debug("AddTask",
+		zap.String("appID", request.Metadata.ApplicationID),
+		zap.String("taskID", request.Metadata.TaskID),
+		zap.Bool("isRecovery", request.Recovery))
 	if managedApp := ctx.GetApplication(request.Metadata.ApplicationID); managedApp != nil {
 		if app, valid := managedApp.(*Application); valid {
 			existingTask, err := app.GetTask(request.Metadata.TaskID)

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -129,9 +129,6 @@ func (ctx *Context) recover(mgr []interfaces.Recoverable, due time.Duration) err
 			// new pods scheduling, due to the fact that we cannot predicate the ordering of K8s
 			// events, it could be dangerous because we might schedule pods onto some node that
 			// doesn't have enough capacity (occupied resources not yet reported).
-			log.Logger.Info("update occupied resources that allocated by other scheduler",
-				zap.String("node", node.Name),
-				zap.String("totalOccupied", occupiedResources.String()))
 			if cachedNode := ctx.nodes.getNode(node.Name); cachedNode != nil {
 				cachedNode.setOccupiedResource(occupiedResources)
 			}

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -102,7 +102,6 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 	if _, ok := nc.nodesMap[node.Name]; !ok {
 		log.Logger.Info("adding node to context",
 			zap.String("nodeName", node.Name),
-			zap.String("UID", string(node.UID)),
 			zap.Bool("schedulable", !node.Spec.Unschedulable))
 		newNode := newSchedulerNode(node.Name, string(node.UID),
 			common.GetNodeResource(&node.Status), nc.proxy, !node.Spec.Unschedulable)
@@ -191,7 +190,6 @@ func (nc *schedulerNodes) updateNode(oldNode, newNode *v1.Node) {
 
 	// node resource changes
 	if equals(oldNode, newNode) {
-		log.Logger.Info("Node status not changed, skip this UpdateNode event")
 		return
 	}
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -38,6 +38,7 @@ import (
 
 type Task struct {
 	taskID         string
+	alias          string
 	applicationID  string
 	application    *Application
 	allocationUUID string
@@ -69,6 +70,7 @@ func createTaskInternal(tid string, app *Application, resource *si.Resource,
 	pod *v1.Pod, ctx *Context) Task {
 	task := Task{
 		taskID:        tid,
+		alias:         fmt.Sprintf("%s/%s", pod.Namespace, pod.Name),
 		applicationID: app.GetApplicationID(),
 		application:   app,
 		pod:           pod,
@@ -117,6 +119,7 @@ func createTaskInternal(tid string, app *Application, resource *si.Resource,
 			states.Rejected:                 task.postTaskRejected,
 			beforeHook(events.CompleteTask): task.beforeTaskCompleted,
 			states.Failed:                   task.postTaskFailed,
+			events.EnterState:               task.enterState,
 		},
 	)
 
@@ -180,6 +183,8 @@ func (task *Task) handleFailEvent(event *fsm.Event) {
 	eventArgs := make([]string, 1)
 	if err := events.GetEventArgsAsStrings(eventArgs, event.Args); err != nil {
 		dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, err.Error()))
+		events.GetRecorder().Eventf(task.pod, v1.EventTypeWarning, "SchedulingFailed",
+			"%s scheduling failed, reason: %s", task.alias, err.Error())
 		return
 	}
 
@@ -200,10 +205,8 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 		return
 	}
 
-	events.GetRecorder().Eventf(task.pod,
-		v1.EventTypeNormal, "TaskSubmitted",
-		"application \"%s\" task \"%s\" is submitted to the scheduler",
-		task.applicationID, task.taskID)
+	events.GetRecorder().Eventf(task.pod, v1.EventTypeNormal, "Scheduling",
+		"%s is queued and waiting for allocation", task.alias)
 
 	// after a small amount of time, if the task is still not able to get allocation,
 	// put the pod to unscheduable state. This will trigger the cluster-auto-scaler to launch
@@ -219,7 +222,7 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 			log.Logger.Debug("updating pod state ",
 				zap.String("appID", task.applicationID),
 				zap.String("taskID", task.taskID),
-				zap.String("podName", fmt.Sprintf("%s/%s", task.pod.Namespace, task.pod.Name)),
+				zap.String("podName", fmt.Sprintf("%s", task.alias)),
 				zap.String("state", "Unscheduable"))
 			// if task state is still pending after 5s,
 			// move task to un-schedule-able state.
@@ -228,14 +231,14 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 					Type:    v1.PodScheduled,
 					Status:  v1.ConditionFalse,
 					Reason:  v1.PodReasonUnschedulable,
-					Message: "retrying scheduling",
+					Message: "pod is unable to be scheduled due to lack of resources",
 				}); err != nil {
 				log.Logger.Error("update pod condition failed",
 					zap.Error(err))
 			}
 			events.GetRecorder().Eventf(task.pod,
-				v1.EventTypeNormal, "TaskStateChanges",
-				"Pod %s state changes to Unscheduable", task.pod.Name)
+				v1.EventTypeNormal, "PodUnscheduable",
+				"Task %s state changes to Unscheduable", task.alias)
 		}
 	})
 }
@@ -273,6 +276,11 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 		allocUUID := eventArgs[0]
 		nodeID := eventArgs[1]
 
+		// post a message to indicate the pod gets its allocation
+		events.GetRecorder().Eventf(task.pod,
+			v1.EventTypeNormal, "Scheduled",
+			"Successfully assigned %s to node %s", task.alias, nodeID)
+
 		// task allocation UID is assigned once we get allocation decision from scheduler core
 		task.allocationUUID = allocUUID
 
@@ -282,8 +290,7 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 			zap.String("podUID", string(task.pod.UID)))
 		if task.context.apiProvider.GetAPIs().VolumeBinder != nil {
 			if err := task.context.bindPodVolumes(task.pod); err != nil {
-				errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, uid: %s, %#v",
-					task.pod.Name, task.pod.UID, err)
+				errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %#v", task.alias, err)
 				dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, errorMessage))
 				events.GetRecorder().Eventf(task.pod,
 					v1.EventTypeWarning, "PodVolumesBindFailure", errorMessage)
@@ -296,8 +303,7 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 			zap.String("podUID", string(task.pod.UID)))
 
 		if err := task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, nodeID); err != nil {
-			errorMessage = fmt.Sprintf("bind pod failed, name: %s, uid: %s, %#v",
-				task.pod.Name, task.pod.UID, err)
+			errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %#v", task.alias, err)
 			log.Logger.Error(errorMessage)
 			dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, errorMessage))
 			events.GetRecorder().Eventf(task.pod,
@@ -309,7 +315,7 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 		dispatcher.Dispatch(NewBindTaskEvent(task.applicationID, task.taskID))
 		events.GetRecorder().Eventf(task.pod,
 			v1.EventTypeNormal, "PodBindSuccessful",
-			"pod \"%s\" successfully bound to node \"%s\"", task.pod.Name, nodeID)
+			"Pod %s is successfully bound to node %s", task.alias, nodeID)
 	}(event)
 }
 
@@ -318,11 +324,11 @@ func (task *Task) postTaskRejected(event *fsm.Event) {
 	// so this function simply triggers the state transition when it is rejected.
 	// but further, we can introduce retry mechanism if necessary.
 	dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID,
-		fmt.Sprintf("task %s failed because it is rejected by scheduler", task.taskID)))
+		fmt.Sprintf("task %s failed because it is rejected by scheduler", task.alias)))
 
 	events.GetRecorder().Eventf(task.pod,
 		v1.EventTypeWarning, "TaskRejected",
-		"application \"%s\" task \"%s\" is rejected by the scheduler", task.applicationID, task.taskID)
+		"Task %s is rejected by the scheduler", task.alias)
 }
 
 func (task *Task) postTaskFailed(event *fsm.Event) {
@@ -331,8 +337,8 @@ func (task *Task) postTaskFailed(event *fsm.Event) {
 	task.releaseAllocation()
 
 	events.GetRecorder().Eventf(task.pod,
-		v1.EventTypeWarning, "TaskFailed",
-		"application \"%s\" task \"%s\" is failed", task.applicationID, task.taskID)
+		v1.EventTypeNormal, "TaskFailed",
+		"Task %s is failed", task.alias)
 }
 
 func (task *Task) beforeTaskCompleted(event *fsm.Event) {
@@ -343,7 +349,7 @@ func (task *Task) beforeTaskCompleted(event *fsm.Event) {
 
 	events.GetRecorder().Eventf(task.pod,
 		v1.EventTypeNormal, "TaskCompleted",
-		"application \"%s\" task \"%s\" is completed", task.applicationID, task.taskID)
+		"Task %s is completed", task.alias)
 }
 
 func (task *Task) releaseAllocation() {
@@ -352,6 +358,7 @@ func (task *Task) releaseAllocation() {
 		log.Logger.Debug("prepare to send release request",
 			zap.String("applicationID", task.applicationID),
 			zap.String("taskID", task.taskID),
+			zap.String("taskAlias", task.alias),
 			zap.String("task", task.GetTaskState()))
 
 		// depends on current task state, generate requests accordingly.
@@ -368,8 +375,12 @@ func (task *Task) releaseAllocation() {
 			releaseRequest = common.CreateReleaseAllocationRequestForTask(
 				task.applicationID, task.allocationUUID, task.application.partition)
 		}
-		log.Logger.Info("send release request",
-			zap.String("releaseRequest", releaseRequest.String()))
+
+		if releaseRequest.Releases != nil {
+			log.Logger.Info("releasing allocations",
+				zap.Int("numOfAsksToRelease", len(releaseRequest.Releases.AllocationAsksToRelease)),
+				zap.Int("numOfAllocationsToRelease", len(releaseRequest.Releases.AllocationsToRelease)))
+		}
 		if err := task.context.apiProvider.GetAPIs().SchedulerAPI.Update(&releaseRequest); err != nil {
 			log.Logger.Debug("failed to send scheduling request to scheduler", zap.Error(err))
 		}
@@ -400,4 +411,12 @@ func (task *Task) sanityCheckBeforeScheduling() error {
 		}
 	}
 	return nil
+}
+
+func (task *Task) enterState(event *fsm.Event) {
+	log.Logger.Info("task state",
+		zap.String("appID", task.applicationID),
+		zap.String("taskID", task.taskID),
+		zap.String("taskAlias", task.alias),
+		zap.String("state", task.GetTaskState()))
 }

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -222,7 +222,7 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 			log.Logger.Debug("updating pod state ",
 				zap.String("appID", task.applicationID),
 				zap.String("taskID", task.taskID),
-				zap.String("podName", fmt.Sprintf("%s", task.alias)),
+				zap.String("podName", task.alias),
 				zap.String("state", "Unscheduable"))
 			// if task state is still pending after 5s,
 			// move task to un-schedule-able state.
@@ -290,7 +290,7 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 			zap.String("podUID", string(task.pod.UID)))
 		if task.context.apiProvider.GetAPIs().VolumeBinder != nil {
 			if err := task.context.bindPodVolumes(task.pod); err != nil {
-				errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %#v", task.alias, err)
+				errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %s", task.alias, err.Error())
 				dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, errorMessage))
 				events.GetRecorder().Eventf(task.pod,
 					v1.EventTypeWarning, "PodVolumesBindFailure", errorMessage)
@@ -303,7 +303,7 @@ func (task *Task) postTaskAllocated(event *fsm.Event) {
 			zap.String("podUID", string(task.pod.UID)))
 
 		if err := task.context.apiProvider.GetAPIs().KubeClient.Bind(task.pod, nodeID); err != nil {
-			errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %#v", task.alias, err)
+			errorMessage = fmt.Sprintf("bind pod volumes failed, name: %s, %s", task.alias, err.Error())
 			log.Logger.Error(errorMessage)
 			dispatcher.Dispatch(NewFailTaskEvent(task.applicationID, task.taskID, errorMessage))
 			events.GetRecorder().Eventf(task.pod,

--- a/pkg/callback/scheduler_callback.go
+++ b/pkg/callback/scheduler_callback.go
@@ -41,12 +41,12 @@ func NewAsyncRMCallback(ctx *cache.Context) *AsyncRMCallback {
 }
 
 func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse) error {
-	log.Logger.Info("callback received",
+	log.Logger.Debug("callback received",
 		zap.String("updateResponse", response.String()))
 
 	// handle new accepted nodes
 	for _, node := range response.AcceptedNodes {
-		log.Logger.Info("callback: response to accepted node",
+		log.Logger.Debug("callback: response to accepted node",
 			zap.String("nodeID", node.NodeID))
 
 		dispatcher.Dispatch(cache.CachedSchedulerNodeEvent{
@@ -56,7 +56,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 	}
 
 	for _, node := range response.RejectedNodes {
-		log.Logger.Info("callback: response to rejected node",
+		log.Logger.Debug("callback: response to rejected node",
 			zap.String("nodeID", node.NodeID))
 
 		dispatcher.Dispatch(cache.CachedSchedulerNodeEvent{
@@ -68,7 +68,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 	// handle new accepted apps
 	for _, app := range response.AcceptedApplications {
 		// update context
-		log.Logger.Info("callback: response to accepted application",
+		log.Logger.Debug("callback: response to accepted application",
 			zap.String("appID", app.ApplicationID))
 
 		if app := callback.context.GetApplication(app.ApplicationID); app != nil {
@@ -79,7 +79,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 
 	for _, app := range response.RejectedApplications {
 		// update context
-		log.Logger.Info("callback: response to rejected application",
+		log.Logger.Debug("callback: response to rejected application",
 			zap.String("appID", app.ApplicationID))
 
 		if app := callback.context.GetApplication(app.ApplicationID); app != nil {
@@ -91,7 +91,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 	// handle new allocations
 	for _, alloc := range response.NewAllocations {
 		// got allocation for pod, bind pod to the scheduled node
-		log.Logger.Info("callback: response to new allocation",
+		log.Logger.Debug("callback: response to new allocation",
 			zap.String("allocationKey", alloc.AllocationKey),
 			zap.String("UUID", alloc.UUID),
 			zap.String("applicationID", alloc.ApplicationID),
@@ -105,7 +105,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 
 	for _, reject := range response.RejectedAllocations {
 		// request rejected by the scheduler, put it back and try scheduling again
-		log.Logger.Info("callback: response to rejected allocation",
+		log.Logger.Debug("callback: response to rejected allocation",
 			zap.String("allocationKey", reject.AllocationKey))
 
 		if app := callback.context.GetApplication(reject.ApplicationID); app != nil {
@@ -116,7 +116,7 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 	}
 
 	for _, release := range response.ReleasedAllocations {
-		log.Logger.Info("callback: response to released allocations",
+		log.Logger.Debug("callback: response to released allocations",
 			zap.String("UUID", release.UUID))
 	}
 

--- a/pkg/common/events/events.go
+++ b/pkg/common/events/events.go
@@ -18,6 +18,8 @@
 
 package events
 
+const EnterState = "enter_state"
+
 //----------------------------------------------
 // General event interface
 //----------------------------------------------

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -240,14 +240,14 @@ func (ss *KubernetesShim) GetSchedulerState() string {
 func (ss *KubernetesShim) handle(se events.SchedulerEvent) error {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
-	log.Logger.Info("shim-scheduler state transition",
+	log.Logger.Debug("shim-scheduler state transition",
 		zap.String("preState", ss.stateMachine.Current()),
 		zap.String("pending event", string(se.GetEvent())))
 	err := ss.stateMachine.Event(string(se.GetEvent()))
 	if err != nil && err.Error() == "no transition" {
 		return err
 	}
-	log.Logger.Info("shim-scheduler state transition",
+	log.Logger.Debug("shim-scheduler state transition",
 		zap.String("postState", ss.stateMachine.Current()))
 	return nil
 }


### PR DESCRIPTION
This PR does

1) Remove unnecessary logs. Such as when predicate fails, we have pushed the info to the event system, we don't need to print the logging again and again. We would see some aggregated message like:

```
Warning  FailedScheduling  2m53s (x24 over 2m53s)  yunikorn                 [Predicate NodeUnknownCondition failed]
```
2) moving some of INFO level to DEBUG
3) Fix format of the event messages pushed to K8s.
4) Added a callback that handles the logging whenever the state changes for app/task

