### PR TITLE
[YUNIKORN-82] Fix wrong revision in docker image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,8 @@ sched_image: scheduler
 	@mkdir -p ./deployments/image/configmap/admission-controller-init-scripts
 	@cp -r ./deployments/admission-controllers/scheduler/*  deployments/image/configmap/admission-controller-init-scripts/
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
-	@coreSHA=$$(go list -m "github.com/apache/incubator-yunikorn-core" | cut -d "-" -f4) ; \
-	siSHA=$$(go list -m "github.com/apache/incubator-yunikorn-scheduler-interface" | cut -d "-" -f5) ; \
+	@coreSHA=$$(go list -m "github.com/apache/incubator-yunikorn-core" | cut -d "-" -f5) ; \
+	siSHA=$$(go list -m "github.com/apache/incubator-yunikorn-scheduler-interface" | cut -d "-" -f6) ; \
 	shimSHA=$$(git rev-parse --short=12 HEAD) ; \
 	docker build ./deployments/image/configmap -t ${REGISTRY}/yunikorn-scheduler-k8s:${VERSION} \
 	--label "yunikorn-core-revision=$${coreSHA}" \


### PR DESCRIPTION
The target split in get-revision commands for yunikorn-core-revision and yunikorn-scheduler-interface-revision should be updated when the project names have changed from "yunikorn-xxx" to "incubator-yunikorn-xxx".