### PR TITLE
[YUNIKORN-84] Always waiting in recovery phase as long as rejected node exists

### DIFF
--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -156,6 +156,8 @@ func (ctx *Context) recover(mgr []interfaces.Recoverable, due time.Duration) err
 				nodesRecovered++
 			case events.States().Node.Draining:
 				nodesRecovered++
+			case events.States().Node.Rejected:
+				nodesRecovered++
 			}
 		}
 

--- a/pkg/cache/context_recovery_test.go
+++ b/pkg/cache/context_recovery_test.go
@@ -19,12 +19,15 @@
 package cache
 
 import (
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
 	"gotest.tools/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
@@ -106,83 +109,91 @@ func TestNodesRecovery(t *testing.T) {
 	dispatcher.Start()
 	defer dispatcher.Stop()
 
-	var node1 = v1.Node{
-		ObjectMeta: apis.ObjectMeta{
-			Name:      "host0001",
-			Namespace: "default",
-			UID:       "uid_0001",
-		},
-		Status: v1.NodeStatus{
-			Capacity: utils.NewK8sResourceList(
-				utils.K8sResource{
-					ResourceName: v1.ResourceMemory,
-					Value:        1024,
-				}, utils.K8sResource{
-					ResourceName: v1.ResourceCPU,
-					Value:        10,
-				}),
-		},
-	}
-
-	var node2 = v1.Node{
-		ObjectMeta: apis.ObjectMeta{
-			Name:      "host0002",
-			Namespace: "default",
-			UID:       "uid_0002",
-		},
-		Status: v1.NodeStatus{
-			Capacity: utils.NewK8sResourceList(
-				utils.K8sResource{
-					ResourceName: v1.ResourceMemory,
-					Value:        1024,
-				}, utils.K8sResource{
-					ResourceName: v1.ResourceCPU,
-					Value:        10,
-				}),
-		},
+	numNodes := 3
+	nodes := make([]*v1.Node, numNodes)
+	expectedStates := make([]string, numNodes)
+	for i := 0; i < numNodes; i++ {
+		nodes[i] = &v1.Node{
+			ObjectMeta: apis.ObjectMeta{
+				Name:      "host000%d" + strconv.Itoa(i),
+				Namespace: "default",
+				UID:       types.UID("uid_000" + strconv.Itoa(i)),
+			},
+			Status: v1.NodeStatus{
+				Capacity: utils.NewK8sResourceList(
+					utils.K8sResource{
+						ResourceName: v1.ResourceMemory,
+						Value:        1024,
+					}, utils.K8sResource{
+						ResourceName: v1.ResourceCPU,
+						Value:        10,
+					}),
+			},
+		}
+		expectedStates[i] = events.States().Node.Recovering
 	}
 
 	nodeLister := test.NewNodeListerMock()
-	nodeLister.AddNode(&node1)
-	nodeLister.AddNode(&node2)
+	for _, node := range nodes {
+		nodeLister.AddNode(node)
+	}
 	apiProvide4test.SetNodeLister(nodeLister)
 
 	mockedAppRecover := test.NewMockedRecoverableAppManager()
-	if err := context.recover([]interfaces.Recoverable{mockedAppRecover}, 3*time.Second); err == nil {
+	if err := context.recover([]interfaces.Recoverable{mockedAppRecover}, 1*time.Second); err == nil {
 		t.Fatalf("expecting timeout here!")
 	} else {
 		t.Logf("context stays waiting for recovery, error: %v", err)
 	}
 
-	sn1 := context.nodes.getNode("host0001")
-	sn2 := context.nodes.getNode("host0002")
+	// verify all nodes were added into context
+	schedulerNodes := make([]*SchedulerNode, len(nodes))
+	for i, node := range nodes {
+		schedulerNodes[i] = context.nodes.getNode(node.Name)
+		assert.Assert(t, schedulerNodes[i] != nil)
+	}
 
-	assert.Assert(t, sn1 != nil)
-	assert.Assert(t, sn2 != nil)
-
-	// node1 recovery is done
+	// dispatch NodeAccepted event for the first node, its expected state should be Healthy
 	dispatcher.Dispatch(CachedSchedulerNodeEvent{
-		NodeID: "host0001",
+		NodeID: schedulerNodes[0].name,
 		Event:  events.NodeAccepted,
 	})
-
+	expectedStates[0] = events.States().Node.Healthy
 	if err := utils.WaitForCondition(func() bool {
-		return sn1.getNodeState() == string(events.States().Node.Healthy) &&
-			sn2.getNodeState() == string(events.States().Node.Recovering)
-	}, time.Second, 5*time.Second); err != nil {
+		return reflect.DeepEqual(getNodeStates(schedulerNodes), expectedStates)
+	}, 100*time.Millisecond, 3*time.Second); err != nil {
 		t.Fatal("unexpected node states")
 	}
 
-	// node2 recovery is done
+	// dispatch NodeRejected event for the second node, its expected state should be Rejected
 	dispatcher.Dispatch(CachedSchedulerNodeEvent{
-		NodeID: "host0002",
+		NodeID: schedulerNodes[1].name,
+		Event:  events.NodeRejected,
+	})
+	expectedStates[1] = events.States().Node.Rejected
+	if err := utils.WaitForCondition(func() bool {
+		return reflect.DeepEqual(getNodeStates(schedulerNodes), expectedStates)
+	}, 100*time.Millisecond, 3*time.Second); err != nil {
+		t.Fatal("unexpected node states")
+	}
+
+	// dispatch DrainNode event for the third node, its expected state should be Draining
+	schedulerNodes[2].schedulable = false
+	dispatcher.Dispatch(CachedSchedulerNodeEvent{
+		NodeID: schedulerNodes[2].name,
 		Event:  events.NodeAccepted,
 	})
-
+	expectedStates[2] = events.States().Node.Draining
 	if err := context.recover([]interfaces.Recoverable{mockedAppRecover}, 3*time.Second); err != nil {
 		t.Fatalf("recovery should be successful, however got error %v", err)
 	}
+	assert.DeepEqual(t, getNodeStates(schedulerNodes), expectedStates)
+}
 
-	assert.Equal(t, sn1.getNodeState(), string(events.States().Node.Healthy))
-	assert.Equal(t, sn2.getNodeState(), string(events.States().Node.Healthy))
+func getNodeStates(schedulerNodes []*SchedulerNode) []string {
+	nodeStates := make([]string, len(schedulerNodes))
+	for i, sn := range schedulerNodes {
+		nodeStates[i] = sn.getNodeState()
+	}
+	return nodeStates
 }

--- a/pkg/cache/context_recovery_test.go
+++ b/pkg/cache/context_recovery_test.go
@@ -142,8 +142,6 @@ func TestNodesRecovery(t *testing.T) {
 	mockedAppRecover := test.NewMockedRecoverableAppManager()
 	if err := context.recover([]interfaces.Recoverable{mockedAppRecover}, 1*time.Second); err == nil {
 		t.Fatalf("expecting timeout here!")
-	} else {
-		t.Logf("context stays waiting for recovery, error: %v", err)
 	}
 
 	// verify all nodes were added into context
@@ -162,7 +160,7 @@ func TestNodesRecovery(t *testing.T) {
 	if err := utils.WaitForCondition(func() bool {
 		return reflect.DeepEqual(getNodeStates(schedulerNodes), expectedStates)
 	}, 100*time.Millisecond, 3*time.Second); err != nil {
-		t.Fatal("unexpected node states")
+		t.Fatalf("unexpected node states, actual: %v, expected: %v", getNodeStates(schedulerNodes), expectedStates)
 	}
 
 	// dispatch NodeRejected event for the second node, its expected state should be Rejected
@@ -174,7 +172,7 @@ func TestNodesRecovery(t *testing.T) {
 	if err := utils.WaitForCondition(func() bool {
 		return reflect.DeepEqual(getNodeStates(schedulerNodes), expectedStates)
 	}, 100*time.Millisecond, 3*time.Second); err != nil {
-		t.Fatal("unexpected node states")
+		t.Fatalf("unexpected node states, actual: %v, expected: %v", getNodeStates(schedulerNodes), expectedStates)
 	}
 
 	// dispatch DrainNode event for the third node, its expected state should be Draining

--- a/pkg/common/events/states.go
+++ b/pkg/common/events/states.go
@@ -57,7 +57,6 @@ type NodeStates struct {
 	Recovering string
 	Accepted   string
 	Healthy    string
-	Unhealthy  string
 	Rejected   string
 	Draining   string
 }
@@ -123,7 +122,6 @@ func States() *AllStates {
 				Recovering: "Recovering",
 				Accepted:   "Accepted",
 				Healthy:    "Healthy",
-				Unhealthy:  "Unhealthy",
 				Rejected:   "Rejected",
 				Draining:   "Draining",
 			},


### PR DESCRIPTION
In recovery phase, scheduler keeps waiting until all nodes are recovered, but not all nodes are considered according to Context#recover in context_recovery.go, only nodes with Healthy or Draining state will be counted, nodes with Rejected state should be counted as well.

Updates:
- nodes with Rejected state are counted
- Improve UT TestNodesRecovery
- Remove unused node state: Unhealthy

@yangwwei @wilfred-s  please help to review this PR. Thanks.