### PR TITLE
[YUNIKORN-121] The admission controller should use hostNetwork

### DIFF
--- a/deployments/admission-controllers/scheduler/templates/server.yaml.template
+++ b/deployments/admission-controllers/scheduler/templates/server.yaml.template
@@ -15,6 +15,7 @@ spec:
       labels:
         app: yunikorn
     spec:
+      hostNetwork: true
       tolerations:
       - operator: "Exists"
       affinity:


### PR DESCRIPTION
When running on EKS, with custom network plugin enabled (e.g calico). Without using hostNetwork, the API server will not be able to connect to the webhook.