### PR TITLE
[YUNIKORN-117] Create event cache for queue and application events

### DIFF
--- a/pkg/shim/main.go
+++ b/pkg/shim/main.go
@@ -44,7 +44,7 @@ func main() {
 	serviceContext := entrypoint.StartAllServices()
 
 	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
-		ss := newShimScheduler(sa, conf.GetSchedulerConf())
+		ss := newShimScheduler(sa, conf.GetSchedulerConf(), serviceContext.EventStore)
 		ss.run()
 
 		signalChan := make(chan os.Signal, 1)

--- a/pkg/shim/scheduler_mock.go
+++ b/pkg/shim/scheduler_mock.go
@@ -72,7 +72,7 @@ func (fc *MockScheduler) init(queues string) {
 	context := cache.NewContext(mockedAPIProvider)
 	rmCallback := callback.NewAsyncRMCallback(context)
 	amSvc := appmgmt.NewAMService(context, mockedAPIProvider)
-	ss := newShimSchedulerInternal(context, mockedAPIProvider, amSvc, rmCallback)
+	ss := newShimSchedulerInternal(context, mockedAPIProvider, amSvc, rmCallback, serviceContext.EventStore)
 
 	fc.context = context
 	fc.scheduler = ss


### PR DESCRIPTION
A way to expose the `EventStore` to the shim