### PR TITLE
[YUNIKORN-166] travis build change leaves code coverage file in the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 _output/
+coverage.txt


### PR DESCRIPTION
Add `coverage.txt` to `.gitignore` .