### PR TITLE
[YUNIKORN-173] Generates one default application ID per namespace in the admission controller

### DIFF
--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -157,7 +157,7 @@ func updateLabels(namespace string, pod *v1.Pod, patch []patchOperation) []patch
 		if _, ok := existingLabels[common.LabelApplicationID]; !ok {
 			// if app id not exist, generate one
 			// for each namespace, we group unnamed pods to one single app
-			// application ID convention: __${NAMESPACE}_app_default
+			// application ID convention: ${AUTO_GEN_PREFIX}-${NAMESPACE}-${AUTO_GEN_SUFFIX}
 			generatedID := generateAppID(namespace)
 			log.Logger.Debug("adding application ID",
 				zap.String("generatedID", generatedID))

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
-	"time"
 
 	"go.uber.org/zap"
 	"k8s.io/api/admission/v1beta1"
@@ -37,6 +35,11 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
+)
+
+const (
+	autoGenAppPrefix = "yunikorn"
+	autoGenAppSuffix = "autogen"
 )
 
 var (
@@ -63,9 +66,10 @@ type ValidateConfResponse struct {
 
 func (c *admissionController) mutate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	req := ar.Request
+	namespace := ar.Request.Namespace
 	log.Logger.Info("AdmissionReview",
 		zap.Any("Kind", req.Kind),
-		zap.String("Namespace", req.Namespace),
+		zap.String("Namespace", namespace),
 		zap.String("UID", string(req.UID)),
 		zap.String("Operation", string(req.Operation)),
 		zap.Any("UserInfo", req.UserInfo))
@@ -93,7 +97,7 @@ func (c *admissionController) mutate(ar *v1beta1.AdmissionReview) *v1beta1.Admis
 		}
 
 		patch = updateSchedulerName(patch)
-		patch = updateLabels(&pod, patch)
+		patch = updateLabels(namespace, &pod, patch)
 	}
 
 	patchBytes, err := json.Marshal(patch)
@@ -125,20 +129,23 @@ func updateSchedulerName(patch []patchOperation) []patchOperation {
 	})
 }
 
-// the generated ID is using [PodName]_[Timestamp] naming convention.
-// the generated ID should be unique even the pod name is same (differ on nano time),
+// generate appID based on the namespace value,
 // and the max length of the ID is 63 chars.
-func generateAppID(podName string) string {
-	timestamp := strconv.FormatInt(time.Now().UnixNano(), 10)
-	generatedID := fmt.Sprintf("%.43s_%.19s", podName, timestamp)
-	return generatedID
+func generateAppID(namespace string) string {
+	ns := "default"
+	if namespace != "" {
+		ns = namespace
+	}
+	generatedID := fmt.Sprintf("%s-%s-%s", autoGenAppPrefix, ns, autoGenAppSuffix)
+	appID := fmt.Sprintf("%.63s", generatedID)
+	return appID
 }
 
-func updateLabels(pod *v1.Pod, patch []patchOperation) []patchOperation {
+func updateLabels(namespace string, pod *v1.Pod, patch []patchOperation) []patchOperation {
 	log.Logger.Info("updating pod labels",
 		zap.String("podName", pod.Name),
 		zap.String("generateName", pod.GenerateName),
-		zap.String("namespace", pod.Namespace),
+		zap.String("namespace", namespace),
 		zap.Any("labels", pod.Labels))
 	existingLabels := pod.Labels
 	result := make(map[string]string)
@@ -149,16 +156,9 @@ func updateLabels(pod *v1.Pod, patch []patchOperation) []patchOperation {
 	if _, ok := existingLabels[common.SparkLabelAppID]; !ok {
 		if _, ok := existingLabels[common.LabelApplicationID]; !ok {
 			// if app id not exist, generate one
-			// pod's name can be generated, if name is not explicitly specified
-			// look for generateName instead
-			podName := "unknown"
-			if pod.Name != "" {
-				podName = pod.Name
-			} else if pod.GenerateName != "" {
-				podName = pod.GenerateName
-			}
-
-			generatedID := generateAppID(podName)
+			// for each namespace, we group unnamed pods to one single app
+			// application ID convention: __${NAMESPACE}_app_default
+			generatedID := generateAppID(namespace)
 			log.Logger.Debug("adding application ID",
 				zap.String("generatedID", generatedID))
 			result[common.LabelApplicationID] = generatedID

--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller_test.go
@@ -54,7 +54,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -63,7 +63,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -91,7 +91,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -128,7 +128,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -137,7 +137,7 @@ func TestUpdateLabels(t *testing.T) {
 		assert.Equal(t, len(updatedMap), 3)
 		assert.Equal(t, updatedMap["random"], "random")
 		assert.Equal(t, updatedMap["queue"], "root.abc")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -160,7 +160,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -168,7 +168,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "a-test-pod"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -188,7 +188,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status: v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -196,7 +196,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "some-pod-"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -214,7 +214,7 @@ func TestUpdateLabels(t *testing.T) {
 		Status:     v1.PodStatus{},
 	}
 
-	patch = updateLabels(pod, patch)
+	patch = updateLabels("default", pod, patch)
 
 	assert.Equal(t, len(patch), 1)
 	assert.Equal(t, patch[0].Op, "add")
@@ -222,7 +222,7 @@ func TestUpdateLabels(t *testing.T) {
 	if updatedMap, ok := patch[0].Value.(map[string]string); ok {
 		assert.Equal(t, len(updatedMap), 2)
 		assert.Equal(t, updatedMap["queue"], "root.default")
-		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], "unknown"), true)
+		assert.Equal(t, strings.HasPrefix(updatedMap["applicationId"], autoGenAppPrefix), true)
 	} else {
 		t.Fatal("patch info content is not as expected")
 	}
@@ -260,19 +260,19 @@ func TestValidateConfigMap(t *testing.T) {
 }
 
 func TestGenerateAppID(t *testing.T) {
-	appID := generateAppID("this-is-a-pod-name")
-	assert.Equal(t, strings.HasPrefix(appID, "this-is-a-pod-name"), true)
-	assert.Equal(t, len(appID), 38)
+	appID := generateAppID("")
+	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-default", autoGenAppPrefix)), true)
+	assert.Equal(t, len(appID), 24)
+
+	appID = generateAppID("this-is-a-namespace")
+	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-this-is-a-namespace", autoGenAppPrefix)), true)
+	assert.Equal(t, len(appID), 36)
 
 	appID = generateAppID("short")
-	assert.Equal(t, strings.HasPrefix(appID, "short"), true)
-	assert.Equal(t, len(appID), 25)
+	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-short", autoGenAppPrefix)), true)
+	assert.Equal(t, len(appID), 22)
 
 	appID = generateAppID(strings.Repeat("long", 100))
-	assert.Equal(t, strings.HasPrefix(appID, "long"), true)
-	assert.Equal(t, len(appID), 63)
-
-	appID = generateAppID("monitoring-prometheus-kube-state-metrics-6484fd9764-ql2w4")
-	assert.Equal(t, strings.HasPrefix(appID, "monitoring-prometheus"), true)
+	assert.Equal(t, strings.HasPrefix(appID, fmt.Sprintf("%s-long", autoGenAppPrefix)), true)
 	assert.Equal(t, len(appID), 63)
 }


### PR DESCRIPTION
See more in https://issues.apache.org/jira/browse/YUNIKORN-173.