### PR TITLE
[YUNIKORN-176] schedulerCache might become inconsistent sometimes depending on the ordering of the events

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -93,10 +93,12 @@ func (cache *SchedulerCache) AddNode(node *v1.Node) {
 	_, ok := cache.nodesMap[node.Name]
 	if !ok {
 		n := schedulernode.NewNodeInfo()
-		// API call always returns nil, never an error
-		//nolint:errcheck
-		_ = n.SetNode(node)
 		cache.nodesMap[node.Name] = n
+	}
+
+	// make sure the node is always linked to the cached node object
+	if err := cache.nodesMap[node.Name].SetNode(node); err != nil {
+		log.Logger.Error("failed to store v1.Node in cache", zap.Error(err))
 	}
 }
 

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -97,7 +97,10 @@ func (cache *SchedulerCache) AddNode(node *v1.Node) {
 	}
 
 	// make sure the node is always linked to the cached node object
+	// Currently, SetNode API call always returns nil, never an error
 	if err := cache.nodesMap[node.Name].SetNode(node); err != nil {
+		// currently, this may never reached because SetNode always return nil
+		// keep the check around to prevent the API changes to provide an error in some cases
 		log.Logger.Error("failed to store v1.Node in cache", zap.Error(err))
 	}
 }

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -1,0 +1,191 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package external
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/assert"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
+)
+
+// this test verifies that no matter which comes first, pod or node,
+// the cache should be updated correctly to contain the correct references
+// for assigned pod, it is stored in the cached node too.
+func TestAssignedPod(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider().GetAPIs())
+
+	resourceList := make(map[v1.ResourceName]resource.Quantity)
+	resourceList[v1.ResourceName("memory")] = *resource.NewQuantity(1024*1000*1000, resource.DecimalSI)
+	resourceList[v1.ResourceName("cpu")] = *resource.NewQuantity(10, resource.DecimalSI)
+
+	node := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "Node-UID-00001",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: resourceList,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod0001",
+			UID:  "Pod-UID-00001",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "host0001",
+		},
+	}
+
+	testCases := []struct {
+		name string
+		arg0 interface{}
+		arg1 interface{}
+	}{
+		{"pod first node second", pod, node},
+		{"node first pod second", node, pod},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := add2Cache(cache, tc.arg0, tc.arg1)
+			assert.NilError(t, err, "add object to scheduler cache failed")
+
+			// verify the node is added to cache
+			// the cached node has reference to the v1.Node object
+			// the cached node has no pods assigned
+			cachedNode := cache.GetNode(node.Name)
+			assert.Check(t, cachedNode != nil, "host0001 is not found in cache")
+			assert.Check(t, cachedNode.Node() != nil, "host0001 exists in cache but the ref to v1.Node doesn't exist")
+			assert.Equal(t, cachedNode.Node().Name, node.Name)
+			assert.Equal(t, cachedNode.Node().UID, node.UID)
+			assert.Equal(t, len(cachedNode.Pods()), 1)
+
+			// verify the pod is added to cache
+			// the pod should be added to the node as well
+			cachedPod, exist := cache.GetPod("Pod-UID-00001")
+			assert.Equal(t, exist, true)
+			assert.Equal(t, cachedPod.Name, pod.Name)
+			assert.Equal(t, cachedPod.UID, pod.UID)
+		})
+	}
+}
+
+// this test verifies that no matter which comes first, pod or node,
+// the cache should be updated correctly to contain the correct references
+// for unassigned pod, it will not be stored in the cached node.
+func TestAddUnassignedPod(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider().GetAPIs())
+
+	resourceList := make(map[v1.ResourceName]resource.Quantity)
+	resourceList[v1.ResourceName("memory")] = *resource.NewQuantity(1024*1000*1000, resource.DecimalSI)
+	resourceList[v1.ResourceName("cpu")] = *resource.NewQuantity(10, resource.DecimalSI)
+
+	node := &v1.Node{
+		ObjectMeta: apis.ObjectMeta{
+			Name:      "host0001",
+			Namespace: "default",
+			UID:       "Node-UID-00001",
+		},
+		Status: v1.NodeStatus{
+			Allocatable: resourceList,
+		},
+		Spec: v1.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod0001",
+			UID:  "Pod-UID-00001",
+		},
+		Spec: v1.PodSpec{},
+	}
+
+	testCases := []struct {
+		name string
+		arg0 interface{}
+		arg1 interface{}
+	}{
+		{"pod first node second", pod, node},
+		{"node first pod second", node, pod},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := add2Cache(cache, tc.arg0, tc.arg1)
+			assert.NilError(t, err, "add object to scheduler cache failed")
+
+			// verify the node is added to cache
+			// the cached node has reference to the v1.Node object
+			// the cached node has no pods assigned
+			cachedNode := cache.GetNode(node.Name)
+			assert.Check(t, cachedNode != nil, "host0001 is not found in cache")
+			assert.Check(t, cachedNode.Node() != nil, "host0001 exists in cache but the ref to v1.Node doesn't exist")
+			assert.Equal(t, cachedNode.Node().Name, node.Name)
+			assert.Equal(t, cachedNode.Node().UID, node.UID)
+			assert.Equal(t, len(cachedNode.Pods()), 0)
+
+			// verify the pod is added to cache
+			// the pod should be added to the node as well
+			cachedPod, exist := cache.GetPod("Pod-UID-00001")
+			assert.Equal(t, exist, true)
+			assert.Equal(t, cachedPod.Name, pod.Name)
+			assert.Equal(t, cachedPod.UID, pod.UID)
+		})
+	}
+}
+
+func add2Cache(cache *SchedulerCache, objects ...interface{}) error {
+	for _, obj := range objects {
+		switch podOrNode := obj.(type) {
+		case *v1.Node:
+			cache.AddNode(podOrNode)
+		case *v1.Pod:
+			err := cache.AddPod(podOrNode)
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unknown object type")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
See more description in https://issues.apache.org/jira/browse/YUNIKORN-176