### PR TITLE
[YUNIKORN-220] Some nodes might be missing if the addNode event is missing

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -111,7 +111,7 @@ func (cache *SchedulerCache) UpdateNode(oldNode, newNode *v1.Node) error {
 
 	n, ok := cache.nodesMap[newNode.Name]
 	if !ok {
-		log.Logger.Warn("updated node doesn't exist in cache, add it!",
+		log.Logger.Warn("updated node info not found, adding it to the cache",
 			zap.String("nodeName", newNode.Name))
 		n = schedulernode.NewNodeInfo()
 		cache.nodesMap[newNode.Name] = n

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -109,15 +109,15 @@ func (cache *SchedulerCache) UpdateNode(oldNode, newNode *v1.Node) error {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 
-	n, ok := cache.nodesMap[oldNode.Name]
-	if ok {
-		// API calls always returns nil, never an error
-		//nolint:errcheck
-		_ = n.RemoveNode(oldNode)
-		//nolint:errcheck
-		_ = n.SetNode(newNode)
+	n, ok := cache.nodesMap[newNode.Name]
+	if !ok {
+		log.Logger.Warn("updated node doesn't exist in cache, add it!",
+			zap.String("nodeName", newNode.Name))
+		n = schedulernode.NewNodeInfo()
+		cache.nodesMap[newNode.Name] = n
 	}
-	return nil
+
+	return n.SetNode(newNode)
 }
 
 func (cache *SchedulerCache) RemoveNode(node *v1.Node) error {

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -178,6 +178,14 @@ func (nc *schedulerNodes) updateNodeOccupiedResources(name string, resource *si.
 }
 
 func (nc *schedulerNodes) updateNode(oldNode, newNode *v1.Node) {
+	// before updating a node, check if it exists in the cache or not
+	// if we receive a update node event but the node doesn't exist,
+	// we need to add it instead of updating it.
+	if cachedNode := nc.getNode(newNode.Name); cachedNode == nil {
+		nc.addNode(newNode)
+		return
+	}
+
 	nc.lock.Lock()
 	defer nc.lock.Unlock()
 

--- a/pkg/common/test/schedulerapi_mock.go
+++ b/pkg/common/test/schedulerapi_mock.go
@@ -91,3 +91,8 @@ func (api *SchedulerAPIMock) GetRegisterCount() int32 {
 func (api *SchedulerAPIMock) GetUpdateCount() int32 {
 	return atomic.LoadInt32(&api.updateCount)
 }
+
+func (api *SchedulerAPIMock) ResetAllCounters() {
+	atomic.StoreInt32(&api.registerCount, 0)
+	atomic.StoreInt32(&api.updateCount, 0)
+}


### PR DESCRIPTION
Some times we found the scheduler state is being inconsistent with K8s. Looks like some addNode was not sent by the informer. In such case, we should make sure the node can be added as well via updateNode event.