### PR TITLE
[YUNIKORN-224] False alarm in the log while removing a pod from scheduler cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ go 1.12
 
 require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20200212043150-3df703098970
-	github.com/apache/incubator-yunikorn-core v0.0.0-20200601201758-fc196adbafbc
+	github.com/apache/incubator-yunikorn-core v0.0.0-20200612225821-42763f5385c7
 	github.com/apache/incubator-yunikorn-scheduler-interface v0.8.1-0.20200601033744-f86297aaea9e
 	github.com/coreos/etcd v3.3.20+incompatible // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/apache/incubator-yunikorn-core v0.0.0-20200530022047-201bbb45e3bf h1:
 github.com/apache/incubator-yunikorn-core v0.0.0-20200530022047-201bbb45e3bf/go.mod h1:5p0hHyU3l79nbo5GoW4rPq9b6Zoc42ID1tNQ4+6cY5A=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200601201758-fc196adbafbc h1:h1vmTpoqrv0+EQVGaq+V94jq7dtJ/XQz9olqmnK++VY=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200601201758-fc196adbafbc/go.mod h1:5p0hHyU3l79nbo5GoW4rPq9b6Zoc42ID1tNQ4+6cY5A=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200612225821-42763f5385c7 h1:soCeNGzX6zzy3EnYl+M2oy3BVwBI2WV+EXBXZ+2Q8mI=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200612225821-42763f5385c7/go.mod h1:5p0hHyU3l79nbo5GoW4rPq9b6Zoc42ID1tNQ4+6cY5A=
 github.com/apache/incubator-yunikorn-core v0.8.0 h1:U7ARr+BHM5IxQM9Tgnk6WeL3HbyD4wTvutmTggG75CA=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f h1:MO1PV62hmeaahOItQq848+aSbypnjdtXj4k0v+O4+nI=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f/go.mod h1:De+73NNH4KaRL9MGGnCyHJOtx2oQGVYOaespfoRNGSo=

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -247,7 +247,7 @@ func (cache *SchedulerCache) RemovePod(pod *v1.Pod) error {
 func (cache *SchedulerCache) removePod(pod *v1.Pod) error {
 	n, ok := cache.nodesMap[pod.Spec.NodeName]
 	if !ok {
-		return fmt.Errorf("node %v is not found", pod.Spec.NodeName)
+		return nil
 	}
 	if err := n.RemovePod(pod); err != nil {
 		return err


### PR DESCRIPTION
This is a false alarm, we do not need to throw an error when node is not found while removing a pod, just like: https://github.com/kubernetes/kubernetes/blob/2402bfd4bc329ae755250f5214351b1408a48eab/pkg/scheduler/internal/cache/cache.go#L446.

This is just like what commented here:
```
// Removes a pod from the cached node info. When a node is removed, some pod
// deletion events might arrive later. This is not a problem, as the pods in
// the node are assumed to be removed already.
```
