### PR TITLE
[YUNIKORN-258] fix make lint to really run

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ run:
   issues-exit-code: 1
   skip-dirs-use-default: true
   modules-download-mode: readonly
+  deadline: 5m
 
 # settings of specific linters
 linters-settings:
@@ -34,6 +35,9 @@ linters-settings:
     local-prefixes: github.com/apache/incubator-yunikorn
   govet:
     check-shadowing: true
+  funlen:
+    lines: 120
+    statements: 80
   depguard:
     list-type: blacklist
     include-go-root: false

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ lint:
 			exit 1; \
 		fi \
 	fi ; \
-	$${lintBin} run --new
+	headSHA=$$(git rev-parse --short=12 origin/HEAD) ; \
+	$${lintBin} run --new-from-rev=$${headSHA}
 
 .PHONY: license-check
 license-check:


### PR DESCRIPTION
The make target for lint in the shim only works if there are uncommitted
changes. In all other cases the check will pass. That means the PR
pre-commit check in travis will never fail.
Fix the lint target to perform the same check as the core