### PR TITLE
[YUNIKORN-241] fix the pod ordering in k8shim

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ go 1.12
 
 require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20200212043150-3df703098970
-	github.com/apache/incubator-yunikorn-core v0.0.0-20200617005428-7529703804b3
+	github.com/apache/incubator-yunikorn-core v0.0.0-20200626030104-5553cbad86ae
 	github.com/apache/incubator-yunikorn-scheduler-interface v0.8.1-0.20200613000533-a889c9d6bafc
 	github.com/coreos/etcd v3.3.20+incompatible // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/apache/incubator-yunikorn-core v0.0.0-20200612225821-42763f5385c7 h1:
 github.com/apache/incubator-yunikorn-core v0.0.0-20200612225821-42763f5385c7/go.mod h1:5p0hHyU3l79nbo5GoW4rPq9b6Zoc42ID1tNQ4+6cY5A=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200617005428-7529703804b3 h1:I9oaHK1Z5FYlabWdayukOtWLwp0otatl6mMBOpERqWQ=
 github.com/apache/incubator-yunikorn-core v0.0.0-20200617005428-7529703804b3/go.mod h1:9hkNjP9kYi8I1Wr98cAGpzSGf5/aOgBclJ5PmG5/jwk=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200626030104-5553cbad86ae h1:v2ZlwWL3lPcmRO2k332n5siIwaKT8y2tssXcz4YgsvI=
+github.com/apache/incubator-yunikorn-core v0.0.0-20200626030104-5553cbad86ae/go.mod h1:9hkNjP9kYi8I1Wr98cAGpzSGf5/aOgBclJ5PmG5/jwk=
 github.com/apache/incubator-yunikorn-core v0.8.0 h1:U7ARr+BHM5IxQM9Tgnk6WeL3HbyD4wTvutmTggG75CA=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f h1:MO1PV62hmeaahOItQq848+aSbypnjdtXj4k0v+O4+nI=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20200414171840-a773cd557b1f/go.mod h1:De+73NNH4KaRL9MGGnCyHJOtx2oQGVYOaespfoRNGSo=

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -20,6 +20,7 @@ package cache
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/looplab/fsm"
@@ -220,6 +221,14 @@ func (app *Application) getTasks(state string) []*Task {
 			}
 		}
 	}
+
+	// sort the task based on creation time
+	sort.Slice(taskList, func(i, j int) bool {
+		l := taskList[i]
+		r := taskList[j]
+		return l.createTime.Before(r.createTime)
+	})
+
 	return taskList
 }
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -46,6 +46,7 @@ type Task struct {
 	pod            *v1.Pod
 	context        *Context
 	nodeName       string
+	createTime     time.Time
 	sm             *fsm.FSM
 	lock           *sync.RWMutex
 }
@@ -75,6 +76,7 @@ func createTaskInternal(tid string, app *Application, resource *si.Resource,
 		application:   app,
 		pod:           pod,
 		resource:      resource,
+		createTime:    pod.GetCreationTimestamp().Time,
 		context:       ctx,
 		lock:          &sync.RWMutex{},
 	}

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -392,7 +392,7 @@ func TestSortTasks(t *testing.T) {
 
 	tasks := app.GetNewTasks()
 	assert.Equal(t, len(tasks), 3)
-	assert.Equal(t, tasks[0], &task0)
-	assert.Equal(t, tasks[1], &task1)
-	assert.Equal(t, tasks[2], &task2)
+	assert.Equal(t, tasks[0], task0)
+	assert.Equal(t, tasks[1], task1)
+	assert.Equal(t, tasks[2], task2)
 }

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	"gotest.tools/assert"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
@@ -292,4 +294,105 @@ func TestReleaseTaskAsk(t *testing.T) {
 	assert.Equal(t, task.GetTaskState(), events.States().Task.Completed)
 	// 2 updates call, 1 for submit, 1 for release
 	assert.Equal(t, mockedApiProvider.GetSchedulerApiUpdateCount(), int32(2))
+}
+
+func TestCreateTask(t *testing.T) {
+	time0 := time.Now()
+	mockedContext := initContextForTest()
+	mockedSchedulerAPI := newMockSchedulerAPI()
+	app := NewApplication("app01", "root.default",
+		"bob", map[string]string{}, mockedSchedulerAPI)
+
+	// pod has timestamp defined
+	pod0 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:              "pod-00",
+			UID:               "UID-00",
+			CreationTimestamp: metav1.Time{Time: time0},
+		},
+	}
+
+	// pod has no timestamp defined
+	pod1 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name: "pod-00",
+			UID:  "UID-00",
+		},
+	}
+
+	// make sure the time is passed in to the task
+	task0 := NewTask("task00", app, mockedContext, pod0)
+	assert.Equal(t, task0.createTime, time0)
+
+	// if pod doesn't have timestamp defined, uses the default value
+	task1 := NewTask("task01", app, mockedContext, pod1)
+	assert.Equal(t, task1.createTime, time.Time{})
+}
+
+func TestSortTasks(t *testing.T) {
+	time0 := time.Now()
+	time1 := time0.Add(10 * time.Millisecond)
+	time2 := time1.Add(10 * time.Millisecond)
+
+	mockedContext := initContextForTest()
+	mockedSchedulerAPI := newMockSchedulerAPI()
+	app := NewApplication("app01", "root.default",
+		"bob", map[string]string{}, mockedSchedulerAPI)
+
+	pod0 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:              "pod-00",
+			UID:               "UID-00",
+			CreationTimestamp: metav1.Time{Time: time0},
+		},
+	}
+
+	pod1 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:              "pod-01",
+			UID:               "UID-01",
+			CreationTimestamp: metav1.Time{Time: time1},
+		},
+	}
+
+	pod2 := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:              "pod-02",
+			UID:               "UID-02",
+			CreationTimestamp: metav1.Time{Time: time2},
+		},
+	}
+
+	task0 := NewTask("task00", app, mockedContext, pod0)
+	task1 := NewTask("task01", app, mockedContext, pod1)
+	task2 := NewTask("task02", app, mockedContext, pod2)
+	app.addTask(task0)
+	app.addTask(task1)
+	app.addTask(task2)
+
+	tasks := app.GetNewTasks()
+	assert.Equal(t, len(tasks), 3)
+	assert.Equal(t, tasks[0], &task0)
+	assert.Equal(t, tasks[1], &task1)
+	assert.Equal(t, tasks[2], &task2)
 }


### PR DESCRIPTION
The pod ordering in the shim was not preserved, which causes the problem for scheduling some daemonset pods.