### PR TITLE
[YUNIKORN-279] Admission controller post-install needs to clean up key files to avoid leaking sensitive info.

### DIFF
--- a/deployments/admission-controllers/scheduler/admission_util.sh
+++ b/deployments/admission-controllers/scheduler/admission_util.sh
@@ -131,6 +131,10 @@ create_resources() {
     kubectl create -f ${admission}.yaml
   done
 
+  # at this point, we should have the webhook installed and started
+  # cleanup the tmp files
+  rm -rf ${KEY_DIR}
+
   echo "The webhook server has been deployed and configured!"
   return 0
 }


### PR DESCRIPTION
Post the admission-controller install, we should delete all the temp files, including the keys and certs, to avoid leaking sensitive info.