### PR TITLE
[YUNIKORN-286] Make admission-controller image repo/version/pullPolicy configurable via helm-charts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,6 @@ sched_image: scheduler
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
 	@mkdir -p ./deployments/image/configmap/admission-controller-init-scripts
 	@cp -r ./deployments/admission-controllers/scheduler/*  deployments/image/configmap/admission-controller-init-scripts/
-	@sed -i -e 's@\$${REGISTRY}@'"${REGISTRY}"'@g' deployments/image/configmap/admission-controller-init-scripts/templates/server.yaml.template
-	@sed -i -e 's@\$${VERSION}@'"${VERSION}"'@g' deployments/image/configmap/admission-controller-init-scripts/templates/server.yaml.template
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	@coreSHA=$$(go list -m "github.com/apache/incubator-yunikorn-core" | cut -d "-" -f5) ; \
 	siSHA=$$(go list -m "github.com/apache/incubator-yunikorn-scheduler-interface" | cut -d "-" -f6) ; \

--- a/deployments/admission-controllers/scheduler/admission_util.sh
+++ b/deployments/admission-controllers/scheduler/admission_util.sh
@@ -43,6 +43,15 @@ REGISTERED_ADMISSIONS=${REGISTERED_ADMISSIONS//,/ }
 if [ -z "$SCHEDULER_SERVICE_NAME" ]; then
   SCHEDULER_SERVICE_NAME=`cat ${CONF_FILE} | grep ^schedulerServiceName | cut -d "=" -f 2`
 fi
+if [ -z "$ADMISSION_CONTROLLER_IMAGE_REGISTRY" ]; then
+  ADMISSION_CONTROLLER_IMAGE_REGISTRY=`cat ${CONF_FILE} | grep ^dockerImageRegistry | cut -d "=" -f 2`
+fi
+if [ -z "$ADMISSION_CONTROLLER_IMAGE_TAG" ]; then
+  ADMISSION_CONTROLLER_IMAGE_TAG=`cat ${CONF_FILE} | grep ^dockerImageTag | cut -d "=" -f 2`
+fi
+if [ -z "$ADMISSION_CONTROLLER_IMAGE_PULL_POLICY" ]; then
+  ADMISSION_CONTROLLER_IMAGE_PULL_POLICY=`cat ${CONF_FILE} | grep ^dockerImagePullPolicy | cut -d "=" -f 2`
+fi
 
 delete_resources() {
   kubectl delete -f server.yaml
@@ -123,6 +132,9 @@ create_resources() {
   sed -e 's@${NAMESPACE}@'"$NAMESPACE"'@g' -e 's@${SERVICE}@'"$SERVICE"'@g' \
     -e 's@${POLICY_GROUP}@'"$POLICY_GROUP"'@g' \
     -e 's@${SCHEDULER_SERVICE_ADDRESS}@'"$SCHEDULER_SERVICE_ADDRESS"'@g' \
+    -e 's@${ADMISSION_CONTROLLER_IMAGE_REGISTRY}@'"$ADMISSION_CONTROLLER_IMAGE_REGISTRY"'@g' \
+    -e 's@${ADMISSION_CONTROLLER_IMAGE_TAG}@'"$ADMISSION_CONTROLLER_IMAGE_TAG"'@g' \
+    -e 's@${ADMISSION_CONTROLLER_IMAGE_PULL_POLICY}@'"$ADMISSION_CONTROLLER_IMAGE_PULL_POLICY"'@g' \
     <"${basedir}/templates/server.yaml.template" > server.yaml
   kubectl create -f server.yaml
 

--- a/deployments/admission-controllers/scheduler/configs.properties
+++ b/deployments/admission-controllers/scheduler/configs.properties
@@ -1,5 +1,8 @@
 service=yunikorn-admission-controller-service
 secret=webhook-server-tls
+dockerImageRegistry=apache/yunikorn
+dockerImageTag=admission-latest
+dockerImagePullPolicy=IfNotPresent
 namespace=yunikorn
 # policy group should be consistent between scheduler and admission-controller, by default is 'queues'
 policyGroup=queues

--- a/deployments/admission-controllers/scheduler/templates/server.yaml.template
+++ b/deployments/admission-controllers/scheduler/templates/server.yaml.template
@@ -30,8 +30,8 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: yunikorn-admission-controller-webhook
-          image: ${REGISTRY}/yunikorn:admission-${VERSION}
-          imagePullPolicy: IfNotPresent
+          image: ${ADMISSION_CONTROLLER_IMAGE_REGISTRY}:${ADMISSION_CONTROLLER_IMAGE_TAG}
+          imagePullPolicy: ${ADMISSION_CONTROLLER_IMAGE_PULL_POLICY}
           ports:
           - containerPort: 8443
             name: webhook-api


### PR DESCRIPTION
Currently, the admission controller image repo/version/pullPolicy are generated during make image. That means they cannot be modified from outside. We need to make these field configurable from helm-charts install.
Note, once this change is made, we will need a subsequential task to update the helm-chart in the helm-hub for the latest images.