### PR TITLE
[YUNIKORN-291] Skip updatePodCondition in testing mode.

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -643,14 +643,16 @@ func (ctx *Context) updatePodCondition(task *Task, podCondition *v1.PodCondition
 				zap.Any("podCondition", podCondition))
 			// call api-server to do the pod condition update
 			if podutil.UpdatePodCondition(&task.pod.Status, podCondition) {
-				_, err := ctx.apiProvider.GetAPIs().KubeClient.GetClientSet().CoreV1().
-					Pods(task.pod.Namespace).UpdateStatus(task.pod)
-				if err == nil {
-					return true
+				if !ctx.apiProvider.IsTestingMode() {
+					_, err := ctx.apiProvider.GetAPIs().KubeClient.GetClientSet().CoreV1().
+						Pods(task.pod.Namespace).UpdateStatus(task.pod)
+					if err == nil {
+						return true
+					}
+					// only log the error here, no need to handle it if the update failed
+					log.Logger.Error("update pod condition failed",
+						zap.Error(err))
 				}
-				// only log the error here, no need to handle it if the update failed
-				log.Logger.Error("update pod condition failed",
-					zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
This fixed the UT failure, which happens after event cache updates changes are merged.