### PR TITLE
[YUNIKORN-294] Add e2e test to verify app CRD

### DIFF
--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -104,7 +104,8 @@ function install_cluster() {
   helm install yunikorn yunikorn/yunikorn --namespace yunikorn \
     --set image.repository=local/yunikorn \
     --set image.tag=scheduler-latest \
-    --set image.pullPolicy=Never
+    --set image.pullPolicy=Never \
+    --set installCRD=true
   exit_on_error "failed to install yunikorn"
   kubectl wait --for=condition=available --timeout=300s deployment/yunikorn-scheduler -n yunikorn
   exit_on_error "failed to wait for yunikorn scheduler deployment being deployed"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -48,7 +48,7 @@ OR follow this doc for deploying go https://golang.org/doc/install
 * Launching CI tests is as simple as below.
 ```console
 $ kubectl config use-context <<cluster-under-test-context>>
-$ ginkgo -r -v CI -timeout=2h -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+$ ginkgo -r -v ci -timeout=2h -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
 ```
 
 * Launching all the tests can be done as..

--- a/test/e2e/app/app_suite_test.go
+++ b/test/e2e/app/app_suite_test.go
@@ -1,3 +1,21 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package app
 
 import (

--- a/test/e2e/app/app_suite_test.go
+++ b/test/e2e/app/app_suite_test.go
@@ -1,0 +1,19 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+
+	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/configmanager"
+)
+
+func init() {
+	configmanager.YuniKornTestConfig.ParseFlags()
+}
+
+func TestApp(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "App Suite")
+}

--- a/test/e2e/app/app_test.go
+++ b/test/e2e/app/app_test.go
@@ -1,0 +1,86 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package app
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
+	crdclientset "github.com/apache/incubator-yunikorn-k8shim/pkg/client/clientset/versioned"
+	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/helpers"
+)
+
+var _ = ginkgo.Describe("App", func() {
+	var kClient helpers.KubeCtl
+	var appClient *crdclientset.Clientset
+	var appCRDDef string
+	var appCRD *v1alpha1.Application
+	var dev = "apptest"
+
+	ginkgo.BeforeSuite(func() {
+		// Initializing kubectl client and create test namespace
+		kClient = helpers.KubeCtl{}
+		gomega.Ω(kClient.SetClient()).To(gomega.BeNil())
+		ginkgo.By("create apptest namespace")
+		ns, err := kClient.CreateNamespace(dev)
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		gomega.Ω(ns.Status.Phase).To(gomega.Equal(v1.NamespaceActive))
+
+		ginkgo.By("Deploy the example Application to the apptest namespace")
+		appClient, err = helpers.NewApplicationClient()
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		// error test case
+		apperrDef, err := helpers.GetAbsPath("../testdata/application_error.yaml")
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		_, err = helpers.GetApplicationObj(apperrDef)
+		gomega.Ω(err).To(gomega.HaveOccurred())
+		// correct test case
+		appCRDDef, err = helpers.GetAbsPath("../testdata/application.yaml")
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		appCRDObj, err := helpers.GetApplicationObj(appCRDDef)
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		appCRDObj.Namespace = dev
+		err = helpers.CreateApplication(appClient, appCRDObj, dev)
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		appCRD, err = helpers.GetApplication(appClient, dev, "example")
+		gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		gomega.Ω(appCRD).NotTo(gomega.BeNil())
+	})
+
+	ginkgo.Context("Verifying the application CRD information", func() {
+		ginkgo.It("Verify that the Application is created", func() {
+			ginkgo.By("Verify that the Application is created")
+			gomega.Ω(appCRD.Spec.Queue).To(gomega.Equal("root.default"))
+			gomega.Ω(appCRD.Spec.MaxPendingSeconds).To(gomega.Equal(int32(10)))
+			gomega.Ω(appCRD.ObjectMeta.Name).To(gomega.Equal("example"))
+			gomega.Ω(appCRD.ObjectMeta.Namespace).To(gomega.Equal(dev))
+		})
+
+		ginkgo.AfterSuite(func() {
+			ginkgo.By("Deleting application CRD")
+			err := helpers.DeleteApplication(appClient, dev, "example")
+			gomega.Ω(err).NotTo(gomega.HaveOccurred())
+
+			ginkgo.By("Deleting development namespaces")
+			err = kClient.DeleteNamespace(dev)
+			gomega.Ω(err).NotTo(gomega.HaveOccurred())
+		})
+	})
+})

--- a/test/e2e/ci/ci_test.go
+++ b/test/e2e/ci/ci_test.go
@@ -27,20 +27,15 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
-	crdclientset "github.com/apache/incubator-yunikorn-k8shim/pkg/client/clientset/versioned"
 	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/helpers"
 )
 
 var _ = ginkgo.Describe("CI: Test for basic scheduling", func() {
 	var kClient helpers.KubeCtl
 	var restClient helpers.RClient
-	var appClient *crdclientset.Clientset
 	var sleepPodDef string
-	var appCRDDef string
 	var err error
 	var sleepRespPod *v1.Pod
-	var appCRD *v1alpha1.Application
 	var dev = "development"
 	var appsInfo map[string]interface{}
 	var r = regexp.MustCompile(`memory:(\d+) vcore:(\d+)`)
@@ -57,26 +52,6 @@ var _ = ginkgo.Describe("CI: Test for basic scheduling", func() {
 		ns1, err := kClient.CreateNamespace(dev)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
 		gomega.Ω(ns1.Status.Phase).To(gomega.Equal(v1.NamespaceActive))
-
-		ginkgo.By("Deploy the example Application to the development namespace")
-		appClient, err = helpers.NewApplicationClient()
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		// error test case
-		apperrDef, err := helpers.GetAbsPath("../testdata/application_error.yaml")
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		_, err = helpers.GetApplicationObj(apperrDef)
-		gomega.Ω(err).To(gomega.HaveOccurred())
-		// correct test case
-		appCRDDef, err = helpers.GetAbsPath("../testdata/application.yaml")
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		appCRDObj, err := helpers.GetApplicationObj(appCRDDef)
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		appCRDObj.Namespace = dev
-		err = helpers.CreateApplication(appClient, appCRDObj, dev)
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		appCRD, err = helpers.GetApplication(appClient, dev, "example")
-		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		gomega.Ω(appCRD).NotTo(gomega.BeNil())
 
 		ginkgo.By("Deploy the sleep pod to the development namespace")
 		sleepObj, err := helpers.GetPodObj(sleepPodDef)
@@ -109,14 +84,6 @@ var _ = ginkgo.Describe("CI: Test for basic scheduling", func() {
 			gomega.Ω("yunikorn").To(gomega.Equal(sleepRespPod.Spec.SchedulerName))
 		})
 
-		ginkgo.It("Verify that the Application is created", func() {
-			ginkgo.By("Verify that the Application is created")
-			gomega.Ω(appCRD.Spec.Queue).To(gomega.Equal("root.default"))
-			gomega.Ω(appCRD.Spec.MaxPendingSeconds).To(gomega.Equal(int32(10)))
-			gomega.Ω(appCRD.ObjectMeta.Name).To(gomega.Equal("example"))
-			gomega.Ω(appCRD.ObjectMeta.Namespace).To(gomega.Equal(dev))
-		})
-
 		ginkgo.It("Verify the pod allocation properties", func() {
 			ginkgo.By("Verify the pod allocation properties")
 			gomega.Ω(appsInfo["allocations"]).NotTo(gomega.BeNil())
@@ -138,10 +105,6 @@ var _ = ginkgo.Describe("CI: Test for basic scheduling", func() {
 		ginkgo.AfterSuite(func() {
 			ginkgo.By("Deleting pod with name - " + sleepRespPod.Name)
 			err := kClient.DeletePod(sleepRespPod.Name, dev)
-			gomega.Ω(err).NotTo(gomega.HaveOccurred())
-
-			ginkgo.By("Deleting application CRD")
-			err = helpers.DeleteApplication(appClient, dev, "example")
 			gomega.Ω(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("Deleting development namespaces")

--- a/test/e2e/framework/helpers/application_utils.go
+++ b/test/e2e/framework/helpers/application_utils.go
@@ -3,12 +3,13 @@ package helpers
 import (
 	"os"
 
-	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
-	crdclientset "github.com/apache/incubator-yunikorn-k8shim/pkg/client/clientset/versioned"
-	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/configmanager"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
+	crdclientset "github.com/apache/incubator-yunikorn-k8shim/pkg/client/clientset/versioned"
+	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/configmanager"
 )
 
 func GetApplicationObj(yamlPath string) (*v1alpha1.Application, error) {

--- a/test/e2e/framework/helpers/application_utils.go
+++ b/test/e2e/framework/helpers/application_utils.go
@@ -1,3 +1,21 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package helpers
 
 import (

--- a/test/e2e/framework/helpers/application_utils.go
+++ b/test/e2e/framework/helpers/application_utils.go
@@ -1,0 +1,77 @@
+package helpers
+
+import (
+	"os"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
+	crdclientset "github.com/apache/incubator-yunikorn-k8shim/pkg/client/clientset/versioned"
+	"github.com/apache/incubator-yunikorn-k8shim/test/e2e/framework/configmanager"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func GetApplicationObj(yamlPath string) (*v1alpha1.Application, error) {
+	manifest, err := os.Open(yamlPath)
+	if err != nil {
+		return nil, err
+	}
+	appObj := v1alpha1.Application{}
+	if err := yaml.NewYAMLOrJSONDecoder(manifest, 100).Decode(&appObj); err != nil {
+		return nil, err
+	}
+	return &appObj, nil
+}
+
+func CreateApplication(crdclientset crdclientset.Interface, app *v1alpha1.Application, namespace string) error {
+	_, err := crdclientset.ApacheV1alpha1().Applications(namespace).Create(app)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func UpdateApplication(crdclientset crdclientset.Interface, app *v1alpha1.Application, namespace string) error {
+	_, err := crdclientset.ApacheV1alpha1().Applications(namespace).Update(app)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetApplication(crdclientset crdclientset.Interface, namespace, name string) (*v1alpha1.Application, error) {
+	app, err := crdclientset.ApacheV1alpha1().Applications(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return app, nil
+}
+
+func DeleteApplication(crdclientset crdclientset.Interface, namespace, name string) error {
+	err := crdclientset.ApacheV1alpha1().Applications(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func NewApplicationClient() (*crdclientset.Clientset, error) {
+	kubeconfig := configmanager.YuniKornTestConfig.KubeConfig
+	appClient, err := NewClient(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return appClient, nil
+}
+
+func NewClient(kubeconfig string) (*crdclientset.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	appClient, err := crdclientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return appClient, nil
+}

--- a/test/e2e/testdata/application.yaml
+++ b/test/e2e/testdata/application.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: "yunikorn.apache.org/v1alpha1"
+kind: Application
+metadata:
+  name: example
+spec:
+  queue: root.default
+  maxPendingSeconds: 10

--- a/test/e2e/testdata/application.yaml
+++ b/test/e2e/testdata/application.yaml
@@ -22,3 +22,4 @@ metadata:
 spec:
   queue: root.default
   maxPendingSeconds: 10
+  

--- a/test/e2e/testdata/application_error.yaml
+++ b/test/e2e/testdata/application_error.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+#The error application example for error case
+apiVersion: "yunikorn.apache.org/v1alpha1"
+kind: Application
+metadata:
+  name: example_test
+spec:
+  queue: //////
+  maxPendingSeconds: errortype

--- a/test/e2e/testdata/application_error.yaml
+++ b/test/e2e/testdata/application_error.yaml
@@ -23,3 +23,4 @@ metadata:
 spec:
   queue: //////
   maxPendingSeconds: errortype
+  


### PR DESCRIPTION
Cause the bug of [Yunikorn-314](https://issues.apache.org/jira/browse/YUNIKORN-314)
It will fail in verifying the queue name.
Should wait for Yunikorn-314 be fixed.