### PR TITLE
[YUNIKORN-354] Update YK base docker images to UBI

### DIFF
--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12.13-alpine3.10
+FROM registry.redhat.io/ubi8/go-toolset:1.12.8-45
 
 # admission controller bundles
 RUN apk add curl


### PR DESCRIPTION
Updated the base Docker image for the container

Questions:
- [ ] where should be changed the helm charts?
- [ ] should the base image for the admission controller be changed?
- [ ] add license for UBI image if needed

Tested:
locally using `make clean run` on  docker-desktop
