### PR TITLE
[YUNIKORN-285] change lint sha detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,13 @@ all:
 	$(MAKE) -C $(dir $(BASE_DIR)) build
 
 .PHONY: lint
+# Run lint against the previous commit for PR and branch build
+# In dev setup look at all changes on top of master
+REV := "HEAD^"
+DETACHED := $(findstring "fatal:", $(shell git symbolic-ref HEAD))
+ifndef DETACHED
+REV := "origin/HEAD"
+endif
 lint:
 	@echo "running golangci-lint"
 	@lintBin=$$(go env GOPATH)/bin/golangci-lint ; \
@@ -80,7 +87,8 @@ lint:
 			exit 1; \
 		fi \
 	fi ; \
-	headSHA=$$(git rev-parse --short=12 origin/HEAD) ; \
+	headSHA=$$(git rev-parse --short=12 $(REV)) ; \
+	echo "checking against commit sha $${headSHA}" ; \
 	$${lintBin} run --new-from-rev=$${headSHA}
 
 .PHONY: license-check

--- a/Makefile
+++ b/Makefile
@@ -22,13 +22,13 @@ MOD_VERSION := $(shell awk '/^go/ {print $$2}' go.mod)
 
 GM := $(word 1,$(subst ., ,$(GO_VERSION)))
 MM := $(word 1,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MAJOR; fi)
+FAIL := $(shell if [ $(GM) -lt $(MM) ]; then echo MAJOR; fi)
 ifdef FAIL
 $(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
 GM := $(word 2,$(subst ., ,$(GO_VERSION)))
 MM := $(word 2,$(subst ., ,$(MOD_VERSION)))
-FAIL := $(shell if [[ $(GM) -lt $(MM) ]]; then echo MINOR; fi)
+FAIL := $(shell if [ $(GM) -lt $(MM) ]; then echo MINOR; fi)
 ifdef FAIL
 $(error Build should be run with at least go $(MOD_VERSION) or later, found $(GO_VERSION))
 endif
@@ -72,11 +72,6 @@ all:
 .PHONY: lint
 # Run lint against the previous commit for PR and branch build
 # In dev setup look at all changes on top of master
-REV := "HEAD^"
-DETACHED := $(findstring "fatal:", $(shell git symbolic-ref HEAD))
-ifndef DETACHED
-REV := "origin/HEAD"
-endif
 lint:
 	@echo "running golangci-lint"
 	@lintBin=$$(go env GOPATH)/bin/golangci-lint ; \
@@ -87,7 +82,8 @@ lint:
 			exit 1; \
 		fi \
 	fi ; \
-	headSHA=$$(git rev-parse --short=12 $(REV)) ; \
+	git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^" ; \
+	headSHA=$$(git rev-parse --short=12 $${REV}) ; \
 	echo "checking against commit sha $${headSHA}" ; \
 	$${lintBin} run --new-from-rev=$${headSHA}
 


### PR DESCRIPTION
In a branch or PR the CI build has a limited history and often a
detached head. The lint sha detection does not work in all cases.
Adding detached head detection and changing the default reference for
the sha to HEAD^