### PR TITLE
[YUNIKORN-485] docker image update

### DIFF
--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12.13-alpine3.10
+FROM alpine:latest
 
 # admission controller bundles
 RUN apk add curl

--- a/deployments/image/gang/gangclient/dockerfile
+++ b/deployments/image/gang/gangclient/dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15.2
+FROM alpine:latest
 WORKDIR /gang/client
 ADD . /gang/client 
 ENTRYPOINT ["./simulation-gang-worker"]

--- a/deployments/image/gang/webserver/dockerfile
+++ b/deployments/image/gang/webserver/dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15.2
+FROM alpine:latest
 WORKDIR /gang/server
 ADD . /gang/server
 EXPOSE 8863


### PR DESCRIPTION
The current dockerfiles use a go based image for the scheduler and some
tools. There is no need to deploy with go as part of the image.