### PR TITLE
[YUNIKORN-550] placeholderAsk scaling

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -203,11 +203,7 @@ func (app *Application) setTaskGroups(taskGroups []v1alpha1.TaskGroup) {
 	defer app.lock.Unlock()
 	app.taskGroups = taskGroups
 	for _, taskGroup := range app.taskGroups {
-		placeholderAskBuilder := common.NewResourceBuilder()
-		for resName, resvalue := range taskGroup.MinResource {
-			placeholderAskBuilder.AddResource(resName, int64(taskGroup.MinMember)*resvalue.Value())
-		}
-		app.placeholderAsk = common.Add(app.placeholderAsk, placeholderAskBuilder.Build())
+		app.placeholderAsk = common.Add(app.placeholderAsk, common.GetTGResource(taskGroup.MinResource, int64(taskGroup.MinMember)))
 	}
 }
 

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -117,6 +117,21 @@ func ParseResource(cpuStr, memStr string) *si.Resource {
 	return result.Build()
 }
 
+func GetTGResource(resMap map[string]resource.Quantity, members int64) *si.Resource {
+	result := NewResourceBuilder()
+	for resName, resValue := range resMap {
+		switch resName {
+		case v1.ResourceCPU.String():
+			result.AddResource(constants.CPU, members*resValue.MilliValue())
+		case v1.ResourceMemory.String():
+			result.AddResource(constants.Memory, members*resValue.ScaledValue(resource.Mega))
+		default:
+			result.AddResource(resName, members*resValue.Value())
+		}
+	}
+	return result.Build()
+}
+
 func getResource(resourceList v1.ResourceList) *si.Resource {
 	resources := NewResourceBuilder()
 	for name, value := range resourceList {


### PR DESCRIPTION
Resources inside the shim are scaled before sending to the core. The
placeholderAsk was not scaled before sending to the core causing limit
checks to fail.
Moving the conversion into the common code to line up with other types.