### PR TITLE
[YUNIKORN-628]Publish a pod event to indicate the task is being gang scheduling

### DIFF
--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -265,11 +265,12 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 
 	events.GetRecorder().Eventf(task.pod, v1.EventTypeNormal, "Scheduling",
 		"%s is queued and waiting for allocation", task.alias)
-	// if this task is belong to the gang member, then post a message to indicate the pod will being scheduled as gang member
+	// if this task belongs to a task group, that means the app has gang scheduling enabled
+	// in this case, post an event to indicate the task is being gang scheduled
 	if !task.placeholder && task.taskGroupName != "" {
 		events.GetRecorder().Eventf(task.pod,
 			v1.EventTypeNormal, "GangScheduling",
-			"Pod belongs to the taskGroup %s, it will being scheduled as a gang member", task.taskGroupName)
+			"Pod belongs to the taskGroup %s, it will be scheduled as a gang member", task.taskGroupName)
 	}
 }
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -265,6 +265,12 @@ func (task *Task) handleSubmitTaskEvent(event *fsm.Event) {
 
 	events.GetRecorder().Eventf(task.pod, v1.EventTypeNormal, "Scheduling",
 		"%s is queued and waiting for allocation", task.alias)
+	// if this task is belong to the gang member, then post a message to indicate the pod will being scheduled as gang member
+	if !task.placeholder && task.taskGroupName != "" {
+		events.GetRecorder().Eventf(task.pod,
+			v1.EventTypeNormal, "GangScheduling",
+			"Pod belongs to the taskGroup %s, it will being scheduled as a gang member", task.taskGroupName)
+	}
 }
 
 // this is called after task reaches PENDING state,

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -39,11 +39,6 @@ import (
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
 )
 
-// type recorderTime struct {
-// 	time int64
-// 	lock *sync.RWMutex
-// }
-
 func TestTaskStateTransitions(t *testing.T) {
 	mockedSchedulerApi := newMockSchedulerAPI()
 	mockedContext := initContextForTest()
@@ -453,7 +448,7 @@ func TestSetTaskGroup(t *testing.T) {
 	assert.Equal(t, task.getTaskGroupName(), "test-group")
 }
 
-func TestPostTaskAllocated(t *testing.T) {
+func TestHandleSubmitTaskEvent(t *testing.T) {
 	mockedContext := initContextForTest()
 	mockedSchedulerAPI := newMockSchedulerAPI()
 	rt := &recorderTime{

--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -33,8 +33,11 @@ import (
 
 var eventRecorder record.EventRecorder = record.NewFakeRecorder(1024)
 var once sync.Once
+var lock sync.RWMutex
 
 func GetRecorder() record.EventRecorder {
+	lock.Lock()
+	defer lock.Unlock()
 	once.Do(func() {
 		// note, the initiation of the event recorder requires on a workable Kubernetes client,
 		// in test mode we should skip this and just use a fake recorder instead.
@@ -53,5 +56,7 @@ func GetRecorder() record.EventRecorder {
 }
 
 func SetRecorderForTest(recorder record.EventRecorder) {
+	lock.Lock()
+	defer lock.Unlock()
 	eventRecorder = recorder
 }


### PR DESCRIPTION
### What is this PR for?
Publish the pod level event message to pods, which will be gang scheduled.
Indicate user those pods will be gang scheduled.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-628

### How should this be tested?
Unit test had been added to test the the `GetRecorder()` and `Eventf()` called time. 
### Screenshots (if appropriate)
![628](https://user-images.githubusercontent.com/61864060/114273850-55a5fc00-9a4e-11eb-8526-b487619e4a13.png)
### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
