### PR TITLE
[YUNIKORN-650] Retrieve user identity from predefined labels

### DIFF
--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -48,6 +48,7 @@ ENV KUBE_CLIENT_BURST "1000"
 ENV PREDICATES ""
 ENV OPERATOR_PLUGINS "general"
 ENV ENABLE_CONFIG_HOT_REFRESH "true"
+ENV USER_LABEL_KEY "yunikorn.apache.org/user"
 ENTRYPOINT ["sh", "-c", "/k8s_yunikorn_scheduler \
 -clusterId=${CLUSTER_ID} \
 -clusterVersion=${CLUSTER_VERSION} \
@@ -62,4 +63,5 @@ ENTRYPOINT ["sh", "-c", "/k8s_yunikorn_scheduler \
 -kubeBurst=${KUBE_CLIENT_BURST} \
 -predicates=${PREDICATES} \
 -operatorPlugins=${OPERATOR_PLUGINS} \
--enableConfigHotRefresh=${ENABLE_CONFIG_HOT_REFRESH}"]
+-enableConfigHotRefresh=${ENABLE_CONFIG_HOT_REFRESH} \
+-userLabelKey=${USER_LABEL_KEY}"]

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -48,7 +48,7 @@ ENV KUBE_CLIENT_BURST "1000"
 ENV PREDICATES ""
 ENV OPERATOR_PLUGINS "general"
 ENV ENABLE_CONFIG_HOT_REFRESH "true"
-ENV USER_LABEL_KEY "yunikorn.apache.org/user"
+ENV USER_LABEL_KEY "yunikorn.apache.org/username"
 ENTRYPOINT ["sh", "-c", "/k8s_yunikorn_scheduler \
 -clusterId=${CLUSTER_ID} \
 -clusterVersion=${CLUSTER_VERSION} \

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -122,8 +122,9 @@ func (os *Manager) getAppMetadata(pod *v1.Pod) (interfaces.ApplicationMetadata, 
 	} else {
 		tags[constants.AppTagNamespace] = pod.Namespace
 	}
-	// get the application owner (this is all that is available as far as we can find)
-	user := pod.Spec.ServiceAccountName
+	// get the user from Pod Labels
+	user := utils.GetUserFromPod(pod)
+
 
 	taskGroups, err := utils.GetTaskGroupsFromAnnotation(pod)
 	if err != nil {

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -75,7 +75,7 @@ func TestGetAppMetadata(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00001")
 	assert.Equal(t, app.QueueName, "root.a")
-	assert.Equal(t, app.User, "default")
+	assert.Equal(t, app.User, constants.DefaultUser)
 	assert.DeepEqual(t, app.Tags, map[string]string{"namespace": "default"})
 	assert.Equal(t, app.TaskGroups[0].Name, "test-group-1")
 	assert.Equal(t, app.TaskGroups[0].MinMember, int32(3))
@@ -109,7 +109,7 @@ func TestGetAppMetadata(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00002")
 	assert.Equal(t, app.QueueName, "root.b")
-	assert.Equal(t, app.User, "testuser")
+	assert.Equal(t, app.User, constants.DefaultUser)
 	assert.DeepEqual(t, app.Tags, map[string]string{"namespace": "app-namespace-01"})
 	assert.DeepEqual(t, len(app.TaskGroups), 0)
 

--- a/pkg/appmgmt/general/general_test.go
+++ b/pkg/appmgmt/general/general_test.go
@@ -75,7 +75,7 @@ func TestGetAppMetadata(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00001")
 	assert.Equal(t, app.QueueName, "root.a")
-	assert.Equal(t, app.User, "")
+	assert.Equal(t, app.User, "default")
 	assert.DeepEqual(t, app.Tags, map[string]string{"namespace": "default"})
 	assert.Equal(t, app.TaskGroups[0].Name, "test-group-1")
 	assert.Equal(t, app.TaskGroups[0].MinMember, int32(3))
@@ -92,13 +92,13 @@ func TestGetAppMetadata(t *testing.T) {
 			Namespace: "app-namespace-01",
 			UID:       "UID-POD-00001",
 			Labels: map[string]string{
-				"applicationId": "app00002",
-				"queue":         "root.b",
+				"applicationId":            "app00002",
+				"queue":                    "root.b",
+				"yunikorn.apache.org/user": "testuser",
 			},
 		},
 		Spec: v1.PodSpec{
-			SchedulerName:      constants.SchedulerName,
-			ServiceAccountName: "bob",
+			SchedulerName: constants.SchedulerName,
 		},
 		Status: v1.PodStatus{
 			Phase: v1.PodPending,
@@ -109,7 +109,7 @@ func TestGetAppMetadata(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, app.ApplicationID, "app00002")
 	assert.Equal(t, app.QueueName, "root.b")
-	assert.Equal(t, app.User, "bob")
+	assert.Equal(t, app.User, "testuser")
 	assert.DeepEqual(t, app.Tags, map[string]string{"namespace": "app-namespace-01"})
 	assert.DeepEqual(t, len(app.TaskGroups), 0)
 
@@ -124,8 +124,7 @@ func TestGetAppMetadata(t *testing.T) {
 			UID:       "UID-POD-00001",
 		},
 		Spec: v1.PodSpec{
-			SchedulerName:      constants.SchedulerName,
-			ServiceAccountName: "bob",
+			SchedulerName: constants.SchedulerName,
 		},
 		Status: v1.PodStatus{
 			Phase: v1.PodPending,

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -34,6 +34,8 @@ const AppTagNamespace = "namespace"
 const AppTagNamespaceResourceQuota = "namespace.resourcequota"
 const AppTagNamespaceParentQueue = "namespace.parentqueue"
 const DefaultAppNamespace = "default"
+const DefaultUserLabel = "yunikorn.apache.org/username"
+const DefaultUser = "nobody"
 
 // Resource
 const Memory = "memory"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +32,8 @@ import (
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
 )
 
@@ -217,4 +221,23 @@ func MergeMaps(first, second map[string]string) map[string]string {
 		result[k] = v
 	}
 	return result
+}
+
+// find user name from pod label
+func GetUserFromPod(pod *v1.Pod) string {
+	userLabelKey := conf.GetSchedulerConf().UserLabelKey
+	// User name to be defined in labels
+	for name, value := range pod.Labels {
+		if name == userLabelKey {
+			log.Logger().Info("Found user name from pod labels.",
+				zap.String("userLabel", userLabelKey), zap.String("user", value))
+			return value
+		}
+	}
+	value := constants.DefaultUser
+
+	log.Logger().Info("Unable to retrieve user name from pod labels. Empty user label",
+		zap.String("userLabel", constants.DefaultUserLabel))
+
+	return value
 }

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -367,3 +367,27 @@ func TestMergeMaps(t *testing.T) {
 	assert.Equal(t, result["c"], "c1")
 	assert.Equal(t, result["d"], "d2")
 }
+
+func TestGetUserFromPod(t *testing.T) {
+	userInLabel := "testuser"
+	userNotInLabel := constants.DefaultUser
+	testCases := []struct {
+		name         string
+		pod          *v1.Pod
+		expectedUser string
+	}{
+		{"User defined in label with default key", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{constants.DefaultUserLabel: userInLabel},
+			},
+		}, userInLabel},
+		{"User not defined in label", &v1.Pod{}, userNotInLabel},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			userID := GetUserFromPod(tc.pod)
+			assert.DeepEqual(t, userID, tc.expectedUser)
+		})
+	}
+}

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -152,7 +152,7 @@ func initConfigs() {
 		"configuration hot-refresh. If this value is set to true, the configuration updates in the configmap will be "+
 		"automatically reloaded without restarting the scheduler.")
 	userLabelKey := flag.String("userLabelKey", constants.DefaultUserLabel,
-		"provides label key to be used to identify user")
+		"provide pod label key to be used to identify an user")
 
 	flag.Parse()
 

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -68,6 +68,7 @@ type SchedulerConf struct {
 	Predicates             string        `json:"predicates"`
 	OperatorPlugins        string        `json:"operatorPlugins"`
 	EnableConfigHotRefresh bool          `json:"enableConfigHotRefresh"`
+	UserLabelKey           string        `json:"userLabelKey"`
 	sync.RWMutex
 }
 
@@ -150,6 +151,8 @@ func initConfigs() {
 	enableConfigHotRefresh := flag.Bool("enableConfigHotRefresh", false, "Flag for enabling "+
 		"configuration hot-refresh. If this value is set to true, the configuration updates in the configmap will be "+
 		"automatically reloaded without restarting the scheduler.")
+	userLabelKey := flag.String("userLabelKey", constants.DefaultUserLabel,
+		"provides label key to be used to identify user")
 
 	flag.Parse()
 
@@ -180,5 +183,6 @@ func initConfigs() {
 		Predicates:             *predicateList,
 		OperatorPlugins:        *operatorPluginList,
 		EnableConfigHotRefresh: *enableConfigHotRefresh,
+		UserLabelKey:           *userLabelKey,
 	}
 }

--- a/pkg/conf/schedulerconf_test.go
+++ b/pkg/conf/schedulerconf_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
 )
 
 func TestDefaultValues(t *testing.T) {
@@ -35,4 +37,5 @@ func TestDefaultValues(t *testing.T) {
 	assert.Equal(t, conf.KubeQPS, DefaultKubeQPS)
 	assert.Equal(t, conf.KubeBurst, DefaultKubeBurst)
 	assert.Equal(t, conf.Predicates, "")
+	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel)
 }


### PR DESCRIPTION
### What is this PR for?
Improved methodology for determining k8s user. This PR helps to retrieve user identity from predefined labels

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Remaining tasks are recorded under https://issues.apache.org/jira/browse/YUNIKORN-649

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-650

### How should this be tested?
By passing a Label in the Pod/Deployment that indicates a user. 

### Screenshots (if appropriate)

### Questions:
* [x] - It needs documentation.
https://issues.apache.org/jira/browse/YUNIKORN-651
