### PR TITLE
[YUNIKORN-657] Expose application failure reasons

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -125,7 +125,6 @@ func (os *Manager) getAppMetadata(pod *v1.Pod) (interfaces.ApplicationMetadata, 
 	// get the user from Pod Labels
 	user := utils.GetUserFromPod(pod)
 
-
 	taskGroups, err := utils.GetTaskGroupsFromAnnotation(pod)
 	if err != nil {
 		log.Logger().Error("unable to get taskGroups for pod",

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -539,7 +539,7 @@ func failTaskPodWithReasonAndMsg(task *Task, reason string, msg string) {
 		Message: msg,
 	}
 	log.Logger().Info("setting pod to failed", zap.String("podName", task.GetTaskPod().Name))
-	pod, err := task.UpdateTaskPod(podCopy)
+	pod, err := task.UpdateTaskPodStatus(podCopy)
 	if err != nil {
 		log.Logger().Error("failed to update task pod status", zap.Error(err))
 	} else {

--- a/pkg/cache/application_events.go
+++ b/pkg/cache/application_events.go
@@ -23,12 +23,16 @@ import (
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
 )
 
-// ------------------------
-// SimpleApplicationEvent simples moves application states
-// ------------------------
+// SimpleApplicationEvent simply moves application states
 type SimpleApplicationEvent struct {
 	applicationID string
 	event         events.ApplicationEventType
+}
+
+type ApplicationEvent struct {
+	applicationID string
+	event         events.ApplicationEventType
+	message       string
 }
 
 func NewSimpleApplicationEvent(appID string, eventType events.ApplicationEventType) SimpleApplicationEvent {
@@ -47,6 +51,28 @@ func (st SimpleApplicationEvent) GetArgs() []interface{} {
 }
 
 func (st SimpleApplicationEvent) GetApplicationID() string {
+	return st.applicationID
+}
+
+func NewApplicationEvent(appID string, eventType events.ApplicationEventType, msg string) ApplicationEvent {
+	return ApplicationEvent{
+		applicationID: appID,
+		event:         eventType,
+		message:       msg,
+	}
+}
+
+func (st ApplicationEvent) GetEvent() events.ApplicationEventType {
+	return st.event
+}
+
+func (st ApplicationEvent) GetArgs() []interface{} {
+	args := make([]interface{}, 1)
+	args[0] = st.message
+	return args
+}
+
+func (st ApplicationEvent) GetApplicationID() string {
 	return st.applicationID
 }
 

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -60,6 +60,11 @@ func NewTask(tid string, app *Application, ctx *Context, pod *v1.Pod) *Task {
 	return createTaskInternal(tid, app, taskResource, pod, false, "", ctx)
 }
 
+func NewTaskPlaceholder(tid string, app *Application, ctx *Context, pod *v1.Pod) *Task {
+	taskResource := common.GetPodResource(pod)
+	return createTaskInternal(tid, app, taskResource, pod, true, "", ctx)
+}
+
 func NewFromTaskMeta(tid string, app *Application, ctx *Context, metadata interfaces.TaskMetadata) *Task {
 	taskPod := metadata.Pod
 	taskResource := common.GetPodResource(taskPod)
@@ -212,6 +217,10 @@ func (task *Task) getTaskAllocationUUID() string {
 
 func (task *Task) DeleteTaskPod(pod *v1.Pod) error {
 	return task.context.apiProvider.GetAPIs().KubeClient.Delete(task.pod)
+}
+
+func (task *Task) UpdateTaskPod(pod *v1.Pod) (*v1.Pod, error) {
+	return task.context.apiProvider.GetAPIs().KubeClient.Update(pod)
 }
 
 func (task *Task) isTerminated() bool {

--- a/pkg/cache/task.go
+++ b/pkg/cache/task.go
@@ -219,8 +219,8 @@ func (task *Task) DeleteTaskPod(pod *v1.Pod) error {
 	return task.context.apiProvider.GetAPIs().KubeClient.Delete(task.pod)
 }
 
-func (task *Task) UpdateTaskPod(pod *v1.Pod) (*v1.Pod, error) {
-	return task.context.apiProvider.GetAPIs().KubeClient.Update(pod)
+func (task *Task) UpdateTaskPodStatus(pod *v1.Pod) (*v1.Pod, error) {
+	return task.context.apiProvider.GetAPIs().KubeClient.UpdateStatus(pod)
 }
 
 func (task *Task) isTerminated() bool {

--- a/pkg/callback/scheduler_callback.go
+++ b/pkg/callback/scheduler_callback.go
@@ -78,13 +78,13 @@ func (callback *AsyncRMCallback) RecvUpdateResponse(response *si.UpdateResponse)
 		}
 	}
 
-	for _, app := range response.RejectedApplications {
+	for _, rejectedApp := range response.RejectedApplications {
 		// update context
 		log.Logger().Debug("callback: response to rejected application",
-			zap.String("appID", app.ApplicationID))
+			zap.String("appID", rejectedApp.ApplicationID))
 
-		if app := callback.context.GetApplication(app.ApplicationID); app != nil {
-			ev := cache.NewSimpleApplicationEvent(app.GetApplicationID(), events.RejectApplication)
+		if app := callback.context.GetApplication(rejectedApp.ApplicationID); app != nil {
+			ev := cache.NewApplicationEvent(app.GetApplicationID(), events.RejectApplication, rejectedApp.Reason)
 			dispatcher.Dispatch(ev)
 		}
 	}

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -109,9 +109,9 @@ func (m *MockedAPIProvider) MockCreateFn(cfn func(pod *v1.Pod) (*v1.Pod, error))
 	}
 }
 
-func (m *MockedAPIProvider) MockUpdateFn(cfn func(pod *v1.Pod) (*v1.Pod, error)) {
+func (m *MockedAPIProvider) MockUpdateStatusFn(cfn func(pod *v1.Pod) (*v1.Pod, error)) {
 	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
-		mock.updateFn = cfn
+		mock.updateStatusFn = cfn
 	}
 }
 

--- a/pkg/client/apifactory_mock.go
+++ b/pkg/client/apifactory_mock.go
@@ -109,6 +109,18 @@ func (m *MockedAPIProvider) MockCreateFn(cfn func(pod *v1.Pod) (*v1.Pod, error))
 	}
 }
 
+func (m *MockedAPIProvider) MockUpdateFn(cfn func(pod *v1.Pod) (*v1.Pod, error)) {
+	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
+		mock.updateFn = cfn
+	}
+}
+
+func (m *MockedAPIProvider) MockGetFn(cfn func(podName string) (*v1.Pod, error)) {
+	if mock, ok := m.clients.KubeClient.(*KubeClientMock); ok {
+		mock.getFn = cfn
+	}
+}
+
 func (m *MockedAPIProvider) SetNodeLister(lister corev1.NodeLister) {
 	informer := m.clients.NodeInformer
 	if i, ok := informer.(*test.MockedNodeInformer); ok {

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -34,6 +34,12 @@ type KubeClient interface {
 	// Delete a pod from a host
 	Delete(pod *v1.Pod) error
 
+	// Update a pod from a host
+	Update(pod *v1.Pod) (*v1.Pod, error)
+
+	// Get a pod
+	Get(podNamespace string, podName string) (*v1.Pod, error)
+
 	// minimal expose this, only informers factory needs it
 	GetClientSet() kubernetes.Interface
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -34,8 +34,8 @@ type KubeClient interface {
 	// Delete a pod from a host
 	Delete(pod *v1.Pod) error
 
-	// Update a pod from a host
-	Update(pod *v1.Pod) (*v1.Pod, error)
+	// Update the status of a pod
+	UpdateStatus(pod *v1.Pod) (*v1.Pod, error)
 
 	// Get a pod
 	Get(podNamespace string, podName string) (*v1.Pod, error)

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -118,3 +118,28 @@ func (nc SchedulerKubeClient) Delete(pod *v1.Pod) error {
 	}
 	return nil
 }
+
+func (nc SchedulerKubeClient) Get(podNamespace string, podName string) (*v1.Pod, error) {
+	pod, err := nc.clientSet.CoreV1().Pods(podNamespace).Get(podName, apis.GetOptions{})
+	if err != nil {
+		log.Logger().Warn("failed to get pod",
+			zap.String("namespace", pod.Namespace),
+			zap.String("podName", pod.Name),
+			zap.Error(err))
+		return nil, err
+	}
+	return pod, nil
+}
+
+func (nc SchedulerKubeClient) Update(pod *v1.Pod) (*v1.Pod, error) {
+	var updatedPod *v1.Pod
+	var err error
+	if updatedPod, err = nc.clientSet.CoreV1().Pods(pod.Namespace).UpdateStatus(pod); err != nil {
+		log.Logger().Warn("failed to update pod",
+			zap.String("namespace", pod.Namespace),
+			zap.String("podName", pod.Name),
+			zap.Error(err))
+		return pod, err
+	}
+	return updatedPod, nil
+}

--- a/pkg/client/kubeclient.go
+++ b/pkg/client/kubeclient.go
@@ -131,11 +131,11 @@ func (nc SchedulerKubeClient) Get(podNamespace string, podName string) (*v1.Pod,
 	return pod, nil
 }
 
-func (nc SchedulerKubeClient) Update(pod *v1.Pod) (*v1.Pod, error) {
+func (nc SchedulerKubeClient) UpdateStatus(pod *v1.Pod) (*v1.Pod, error) {
 	var updatedPod *v1.Pod
 	var err error
 	if updatedPod, err = nc.clientSet.CoreV1().Pods(pod.Namespace).UpdateStatus(pod); err != nil {
-		log.Logger().Warn("failed to update pod",
+		log.Logger().Warn("failed to update pod status",
 			zap.String("namespace", pod.Namespace),
 			zap.String("podName", pod.Name),
 			zap.Error(err))

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -33,13 +33,13 @@ import (
 
 // KubeClientMock allows us to inject customized bind/delete pod functions
 type KubeClientMock struct {
-	bindFn    func(pod *v1.Pod, hostID string) error
-	deleteFn  func(pod *v1.Pod) error
-	createFn  func(pod *v1.Pod) (*v1.Pod, error)
-	updateFn  func(pod *v1.Pod) (*v1.Pod, error)
-	getFn     func(podName string) (*v1.Pod, error)
-	clientSet kubernetes.Interface
-	pods      map[string]*v1.Pod
+	bindFn         func(pod *v1.Pod, hostID string) error
+	deleteFn       func(pod *v1.Pod) error
+	createFn       func(pod *v1.Pod) (*v1.Pod, error)
+	updateStatusFn func(pod *v1.Pod) (*v1.Pod, error)
+	getFn          func(podName string) (*v1.Pod, error)
+	clientSet      kubernetes.Interface
+	pods           map[string]*v1.Pod
 }
 
 func NewKubeClientMock() *KubeClientMock {
@@ -59,8 +59,8 @@ func NewKubeClientMock() *KubeClientMock {
 				zap.String("PodName", pod.Name))
 			return pod, nil
 		},
-		updateFn: func(pod *v1.Pod) (*v1.Pod, error) {
-			log.Logger().Info("pod updated",
+		updateStatusFn: func(pod *v1.Pod) (*v1.Pod, error) {
+			log.Logger().Info("pod status updated",
 				zap.String("PodName", pod.Name))
 			return pod, nil
 		},
@@ -95,9 +95,9 @@ func (c *KubeClientMock) Create(pod *v1.Pod) (*v1.Pod, error) {
 	return c.createFn(pod)
 }
 
-func (c *KubeClientMock) Update(pod *v1.Pod) (*v1.Pod, error) {
+func (c *KubeClientMock) UpdateStatus(pod *v1.Pod) (*v1.Pod, error) {
 	c.pods[getPodKey(pod)] = pod
-	return c.updateFn(pod)
+	return c.updateStatusFn(pod)
 }
 
 func (c *KubeClientMock) Get(podNamespace string, podName string) (*v1.Pod, error) {

--- a/pkg/client/kubeclient_mock.go
+++ b/pkg/client/kubeclient_mock.go
@@ -19,21 +19,27 @@
 package client
 
 import (
-	"go.uber.org/zap"
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
+
+	"go.uber.org/zap"
 )
 
-// fake client allows us to inject customized bind/delete pod functions
+// KubeClientMock allows us to inject customized bind/delete pod functions
 type KubeClientMock struct {
 	bindFn    func(pod *v1.Pod, hostID string) error
 	deleteFn  func(pod *v1.Pod) error
 	createFn  func(pod *v1.Pod) (*v1.Pod, error)
+	updateFn  func(pod *v1.Pod) (*v1.Pod, error)
+	getFn     func(podName string) (*v1.Pod, error)
 	clientSet kubernetes.Interface
+	pods      map[string]*v1.Pod
 }
 
 func NewKubeClientMock() *KubeClientMock {
@@ -53,7 +59,18 @@ func NewKubeClientMock() *KubeClientMock {
 				zap.String("PodName", pod.Name))
 			return pod, nil
 		},
+		updateFn: func(pod *v1.Pod) (*v1.Pod, error) {
+			log.Logger().Info("pod updated",
+				zap.String("PodName", pod.Name))
+			return pod, nil
+		},
+		getFn: func(podName string) (*v1.Pod, error) {
+			log.Logger().Info("Getting pod",
+				zap.String("PodName", podName))
+			return nil, nil
+		},
 		clientSet: fake.NewSimpleClientset(),
+		pods:      make(map[string]*v1.Pod),
 	}
 }
 
@@ -74,10 +91,26 @@ func (c *KubeClientMock) Bind(pod *v1.Pod, hostID string) error {
 }
 
 func (c *KubeClientMock) Create(pod *v1.Pod) (*v1.Pod, error) {
+	c.pods[getPodKey(pod)] = pod
 	return c.createFn(pod)
 }
 
+func (c *KubeClientMock) Update(pod *v1.Pod) (*v1.Pod, error) {
+	c.pods[getPodKey(pod)] = pod
+	return c.updateFn(pod)
+}
+
+func (c *KubeClientMock) Get(podNamespace string, podName string) (*v1.Pod, error) {
+	podKey := podNamespace + "/" + podName
+	pod, ok := c.pods[podKey]
+	if ok {
+		return pod, nil
+	}
+	return nil, fmt.Errorf("pod not found: %s/%s", podNamespace, podName)
+}
+
 func (c *KubeClientMock) Delete(pod *v1.Pod) error {
+	delete(c.pods, getPodKey(pod))
 	return c.deleteFn(pod)
 }
 
@@ -87,4 +120,8 @@ func (c *KubeClientMock) GetClientSet() kubernetes.Interface {
 
 func (c *KubeClientMock) GetConfigs() *rest.Config {
 	return nil
+}
+
+func getPodKey(pod *v1.Pod) string {
+	return pod.Namespace + "/" + pod.Name
 }

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -64,3 +64,6 @@ const AnnotationTaskGroups = "yunikorn.apache.org/task-groups"
 const AnnotationSchedulingPolicyParam = "yunikorn.apache.org/schedulingPolicyParameters"
 const SchedulingPolicyTimeoutParam = "placeholderTimeoutInSeconds"
 const SchedulingPolicyParamDelimiter = " "
+
+const ApplicationInsufficientResourcesFailure = "InsufficientResources"
+const ApplicationRejectedFailure = "ApplicationRejected"

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -65,5 +65,5 @@ const AnnotationSchedulingPolicyParam = "yunikorn.apache.org/schedulingPolicyPar
 const SchedulingPolicyTimeoutParam = "placeholderTimeoutInSeconds"
 const SchedulingPolicyParamDelimiter = " "
 
-const ApplicationInsufficientResourcesFailure = "InsufficientResources"
+const ApplicationInsufficientResourcesFailure = "ResourceReservationTimeout"
 const ApplicationRejectedFailure = "ApplicationRejected"

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -58,7 +58,7 @@ func NeedRecovery(pod *v1.Pod) (bool, error) {
 		return true, nil
 	}
 
-	if pod.Status.Phase == v1.PodFailed && pod.Status.Reason == constants.ApplicationRejectedFailure || pod.Status.Reason == constants.ApplicationInsufficientResourcesFailure {
+	if pod.Status.Phase == v1.PodFailed {
 		return false, nil
 	}
 

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -58,6 +58,10 @@ func NeedRecovery(pod *v1.Pod) (bool, error) {
 		return true, nil
 	}
 
+	if pod.Status.Phase == v1.PodFailed && pod.Status.Reason == constants.ApplicationRejectedFailure || pod.Status.Reason == constants.ApplicationInsufficientResourcesFailure {
+		return false, nil
+	}
+
 	return false, fmt.Errorf("unknown pod state %v", pod)
 }
 

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -234,17 +234,7 @@ func (ss *KubernetesShim) GetSchedulerState() string {
 func (ss *KubernetesShim) handle(se events.SchedulerEvent) error {
 	ss.lock.Lock()
 	defer ss.lock.Unlock()
-	var err error
-	if len(se.GetArgs()) >= 1 {
-		eventArgs := make([]string, 2)
-		if err = events.GetEventArgsAsStrings(eventArgs, se.GetArgs()); err != nil {
-			log.Logger().Error("fail to parse event arg", zap.Error(err))
-		}
-		message := eventArgs[1]
-		err = ss.stateMachine.Event(string(se.GetEvent()), message)
-	} else {
-		err = ss.stateMachine.Event(string(se.GetEvent()))
-	}
+	err := ss.stateMachine.Event(string(se.GetEvent()), se.GetArgs())
 	if err != nil && err.Error() == "no transition" {
 		return err
 	}


### PR DESCRIPTION
### What is this PR for?
When an application fails or is rejected by the scheduler, the pods currently stay in pending forever without visibility on what happened to them. This PR propagates the scheduling error or failure to the pods so that the user will be able to see the reason of failure. If third-party operators (e.g. Spark K8s Operator) are used, they can also react according to the pod status change and update the status of the corresponding CRD and possibly retry. Core side changes are in https://github.com/apache/incubator-yunikorn-core/pull/271

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-657

### How should this be tested?
Added unit tests to cover this change. When running in a cluster, tested that scheduling failures will be reflected on the pods:

For example, if an application is rejected, its pods will be marked as failed and its `status` field will be populated with the following information:
```
status:
  message: ' application ''spark-<ID>'' rejected, cannot
    create queue ''root.spark'' without placement rules'
  phase: Failed
  reason: ApplicationRejected
```
Another example is that if a gang-scheduled application cannot successfully run all placeholders before they expire, the app pods' `status` field will show:
```
status:
  message: Scheduling has timed out due to insufficient resources
  phase: Failed
  reason: InsufficientResources
```

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
