### PR TITLE
[YUNIKORN-590] GetPlaceholderTimeoutParam: undefined param is not an error

### DIFF
--- a/pkg/common/utils/gang_utils.go
+++ b/pkg/common/utils/gang_utils.go
@@ -126,7 +126,7 @@ func GetTaskGroupsFromAnnotation(pod *v1.Pod) ([]v1alpha1.TaskGroup, error) {
 func GetPlaceholderTimeoutParam(pod *v1.Pod) (int64, error) {
 	param, ok := pod.Annotations[constants.AnnotationSchedulingPolicyParam]
 	if !ok {
-		return 0, fmt.Errorf("no scheduling policy parameters defined for the pod")
+		return 0, nil
 	}
 	params := strings.Split(param, constants.SchedulingPolicyParamDelimiter)
 	for _, p := range params {
@@ -142,5 +142,5 @@ func GetPlaceholderTimeoutParam(pod *v1.Pod) (int64, error) {
 			return timeout, nil
 		}
 	}
-	return 0, fmt.Errorf("no timeout parameter found")
+	return 0, nil
 }


### PR DESCRIPTION
### What is this PR for?
It isn't an error that schedulingPolicyParameters is undefined.
It should return nil.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-590

### How should this be tested?
I add TestGetPlaceholderTimeoutParam in gang_utils_test.go to observe its behavior.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
