### PR TITLE
YUNIKORN-657: Get the latest copy of a pod before attempting status update. Retry in case of failure

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -557,7 +557,7 @@ func (app *Application) handleFailApplicationEvent(event *fsm.Event) {
 		return
 	}
 	errMsg := eventArgs[0]
-	log.Logger().Info("failApplication reason", zap.String("errMsg", errMsg))
+	log.Logger().Info("failApplication reason", zap.String("applicationID", app.applicationID), zap.String("errMsg", errMsg))
 	// unallocated task states include New, Pending and Scheduling
 	unalloc := app.getTasks(events.States().Task.New)
 	unalloc = append(unalloc, app.getTasks(events.States().Task.Pending)...)


### PR DESCRIPTION
### What is this PR for?
Pod status update may occasionally fail because the pod could have been modified since the last Get operation. This PR changed the status update logic to get the latest version before update. Also retry a few times if the update fails.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-657

### How should this be tested?
Ran a deployment with this patch for two weeks and haven't found another instance where the update didn't work

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
