### PR TITLE
[YUNIKORN-625] Updated CertificateSigningRequest to v1

### DIFF
--- a/deployments/admission-controllers/scheduler/generate-signed-ca.sh
+++ b/deployments/admission-controllers/scheduler/generate-signed-ca.sh
@@ -65,7 +65,7 @@ kubectl delete csr ${csrName} 2>/dev/null || true
 
 # send to K8s
 cat <<EOF | kubectl create -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}
@@ -73,10 +73,11 @@ spec:
   groups:
   - system:authenticated
   request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
   usages:
   - digital signature
   - key encipherment
-  - server auth
+  - client auth
 EOF
 
 # verify CSR has been created

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -21,7 +21,7 @@ FROM alpine:latest
 RUN apk add curl
 RUN apk add jq
 RUN apk add --update openssl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/linux/amd64/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.7/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 COPY admission-controller-init-scripts/admission_util.sh /


### PR DESCRIPTION
### What is this PR for?
Starting from K8s 1.19, v1beta1 version of the CertificateSigningRequest is changed by the v1 version.
Also the kubernetes client version is updated to 1.19.7. Older versions than 1.19 will not recognize
the v1 version and the certificate approval will fail.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [X] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-625

### How should this be tested?
Manually and running the end 2 end test for both later and 1.19 K8s versions

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
