### PR TITLE
[YUNIKORN-674] Fixed admission controller for K8s v. 1.19

### DIFF
--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -21,7 +21,7 @@ FROM alpine:latest
 RUN apk add curl
 RUN apk add jq
 RUN apk add --update openssl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.15.12/bin/linux/amd64/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 COPY admission-controller-init-scripts/admission_util.sh /

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -21,7 +21,7 @@ FROM alpine:latest
 RUN apk add curl
 RUN apk add jq
 RUN apk add --update openssl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/linux/amd64/kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.19.11/bin/linux/amd64/kubectl
 RUN chmod +x ./kubectl
 RUN mv ./kubectl /usr/local/bin/kubectl
 COPY admission-controller-init-scripts/admission_util.sh /


### PR DESCRIPTION
### What is this PR for?
The admission controller failed to start because we failed to generate the certificate.

The error related the cert geneeration is the following one:

`no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"`
Upgrading kubectl to 1.19 will solve the issue for 1.19 version.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [X] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-674

### How should this be tested?
- running the e2e tests for both K8s 1.19 and for older versions as well
- manual tests

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
