### PR TITLE
[YUNIKONR-706] Fix the resource calculation when the pod has init-containers

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -73,21 +73,22 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 		podResource = Add(podResource, containerResource)
 	}
 
-	// vcore, mem compare between initcontainer and containers and replace
-	// For each resource, podResourceRequest = max(sum(Containers requirement), InitContainers requirement)
+	// each resource compare between initcontainer and sum of containers
+	// max(sum(Containers requirement), InitContainers requirement)
 	if pod.Spec.InitContainers != nil {
-		isNeedMoreResourceAndSet(pod, podResource)
+		checkInitContainerRequest(pod, podResource)
 	}
 
 	return podResource
 }
 
-func isNeedMoreResourceAndSet(pod *v1.Pod, containersResources *si.Resource) {
+func checkInitContainerRequest(pod *v1.Pod, containersResources *si.Resource) {
 	for _, c := range pod.Spec.InitContainers {
 		resourceList := c.Resources.Requests
 		ICResource := getResource(resourceList)
 		for resourceName, ICRequest := range ICResource.Resources {
 			containersRequests, exist := containersResources.Resources[resourceName]
+			// addtional resource request from init cont, add it to request.
 			if !exist {
 				containersResources.Resources[resourceName] = ICRequest
 				continue

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -57,7 +57,7 @@ func (w *ResourceBuilder) Build() *si.Resource {
 // values, limits are ignored in the current setup.
 // BestEffort pods are scheduled using a minimum resource of 1MB only.
 func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
-	//var memory, vcore = int64(0), int64(0)
+	// var memory, vcore = int64(0), int64(0)
 	var podResource *si.Resource
 	// A QosBestEffort pod does not request any resources and thus cannot be
 	// scheduled. Handle a QosBestEffort pod by setting a tiny memory value.
@@ -85,14 +85,14 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 func isNeedMoreResourceAndSet(pod *v1.Pod, containersResources *si.Resource) {
 	for _, c := range pod.Spec.InitContainers {
 		resourceList := c.Resources.Requests
-		initCResource := getResource(resourceList)
-		for resourceName, initCRequest := range initCResource.Resources {
+		ICResource := getResource(resourceList)
+		for resourceName, ICRequest := range ICResource.Resources {
 			containersRequests, exist := containersResources.Resources[resourceName]
 			if !exist {
 				continue
 			}
-			if initCRequest.GetValue() > containersRequests.GetValue() {
-				containersResources.Resources[resourceName] = initCRequest
+			if ICRequest.GetValue() > containersRequests.GetValue() {
+				containersResources.Resources[resourceName] = ICRequest
 			}
 		}
 	}

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -82,21 +82,17 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 }
 
 func IsNeedMoreResourceAndSet(pod *v1.Pod, containersResources *si.Resource) {
-	var initContainersResource *si.Resource
-
 	for _, c := range pod.Spec.InitContainers {
 		resourceList := c.Resources.Requests
-		containerResource := getResource(resourceList)
-		initContainersResource = Add(initContainersResource, containerResource)
-	}
-
-	for resouceName, v1 := range initContainersResource.Resources {
-		v2, exist := containersResources.Resources[resouceName]
-		if !exist {
-			continue
-		}
-		if v1.GetValue() > v2.GetValue() {
-			containersResources.Resources[resouceName] = v1
+		initCResource := getResource(resourceList)
+		for resouceName, v1 := range initCResource.Resources {
+			v2, exist := containersResources.Resources[resouceName]
+			if !exist {
+				continue
+			}
+			if v1.GetValue() > v2.GetValue() {
+				containersResources.Resources[resouceName] = v1
+			}
 		}
 	}
 }

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -89,6 +89,7 @@ func isNeedMoreResourceAndSet(pod *v1.Pod, containersResources *si.Resource) {
 		for resourceName, ICRequest := range ICResource.Resources {
 			containersRequests, exist := containersResources.Resources[resourceName]
 			if !exist {
+				containersResources.Resources[resourceName] = ICRequest
 				continue
 			}
 			if ICRequest.GetValue() > containersRequests.GetValue() {

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -73,7 +73,7 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 		podResource = Add(podResource, containerResource)
 	}
 
-	//vcore, mem compare between initcontainers and containers and replace(choose bigger one)
+	// vcore, mem compare between initcontainer and containers and replace(choose bigger one)
 	if pod.Spec.InitContainers != nil {
 		IsNeedMoreResourceAndSet(pod, podResource)
 	}

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -223,25 +223,18 @@ func TestParsePodResource(t *testing.T) {
 	containers[1].Resources.Requests[v1.ResourceCPU] = resource.MustParse("1.024")
 	containers[1].Resources.Requests[v1.ResourceName("nvidia.com/gpu")] = resource.MustParse("2")
 
-	pod = &v1.Pod{
-		TypeMeta: apis.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: "v1",
-		},
-		ObjectMeta: apis.ObjectMeta{
-			Name: "pod-resource-test-00002",
-			UID:  "UID-00002",
-		},
-		Spec: v1.PodSpec{
-			Containers:     containers,
-			InitContainers: initContainers,
-		},
+	pod.ObjectMeta = apis.ObjectMeta{
+		Name: "pod-resource-test-00002",
+		UID:  "UID-00002",
 	}
-
+	pod.Spec = v1.PodSpec{
+		Containers:     containers,
+		InitContainers: initContainers,
+	}
 	// initcontainers
 	// IC1{500mi, 1000m, 1}
 	// IC2{5120mi, 10000m, 4}
-	// containers
+	// sum of containers{5120mi, 7000m, 4}
 	// C1{4096mi, 2000m, 2}
 	// C2{1024mi, 5000m, 2}
 	// result {5120mi, 10000m, 4}
@@ -258,6 +251,9 @@ func TestParsePodResource(t *testing.T) {
 		Containers:     containers,
 		InitContainers: initContainers,
 	}
+	// IC1{500mi, 1000m, 1}
+	// IC2{0mi, 10000m}
+	// sum of containers{5120mi, 7000m}
 	// result {5120mi, 10000m, 1}
 	res = GetPodResource(pod)
 	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(10000))

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -233,7 +233,6 @@ func TestParsePodResource(t *testing.T) {
 	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(4096))
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(5000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
-
 }
 
 func TestBestEffortPod(t *testing.T) {

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -229,6 +229,14 @@ func TestParsePodResource(t *testing.T) {
 			InitContainers: initContainers,
 		},
 	}
+	// pod
+	// initcontainers
+	// IC1{500mi, 1000m, 1}
+	// IC2{1024mi, 2000m, 4}
+	// containers
+	// C1{4096mi, 2000m, 2}
+	// C2{1024mi, 5000m, 2}
+	// result is {4096mi, 5000m, 5}
 	res = GetPodResource(pod)
 	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(4096))
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(5000))

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -194,7 +194,7 @@ func TestParsePodResource(t *testing.T) {
 	//test initcontainer and container resouce compare
 	initContainers := make([]v1.Container, 0)
 	initc1Resources := make(map[v1.ResourceName]resource.Quantity)
-	initc1Resources[v1.ResourceMemory] = resource.MustParse("1024M")
+	initc1Resources[v1.ResourceMemory] = resource.MustParse("4096M")
 	initc1Resources[v1.ResourceCPU] = resource.MustParse("2")
 	initc1Resources[v1.ResourceName("nvidia.com/gpu")] = resource.MustParse("2")
 	initContainers = append(initContainers, v1.Container{
@@ -206,7 +206,7 @@ func TestParsePodResource(t *testing.T) {
 
 	initc2Resources := make(map[v1.ResourceName]resource.Quantity)
 	initc2Resources[v1.ResourceMemory] = resource.MustParse("1024M")
-	initc2Resources[v1.ResourceCPU] = resource.MustParse("2")
+	initc2Resources[v1.ResourceCPU] = resource.MustParse("5")
 	initc2Resources[v1.ResourceName("nvidia.com/gpu")] = resource.MustParse("2")
 	initContainers = append(initContainers, v1.Container{
 		Name: "initcontainer-02",
@@ -230,8 +230,8 @@ func TestParsePodResource(t *testing.T) {
 		},
 	}
 	res = GetPodResource(pod)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(2048))
-	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(4000))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(4096))
+	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(5000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 
 }

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -191,7 +191,7 @@ func TestParsePodResource(t *testing.T) {
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(3000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 
-	//test initcontainer and container resouce compare
+	// test initcontainer and container resouce compare
 	initContainers := make([]v1.Container, 0)
 	initc1Resources := make(map[v1.ResourceName]resource.Quantity)
 	initc1Resources[v1.ResourceMemory] = resource.MustParse("4096M")


### PR DESCRIPTION
### What is this PR for?
Original function will miss initcontainers requirement in podspec when pod has initcontainers and containers.
The reason is that resources calculation function only check resources requirement of containers in pod.
I modify resource calculation in task which use function in common package to confirm it.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-706

### How should this be tested?
I add test case to check calculation correctly.
Use make test to check.
### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
