### PR TITLE
[YUNIKORN-754] Fix web link about build document in readme of incubator…

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ YuniKorn scheduler shim for kubernetes is a customized k8s scheduler, it can be 
 This project contains the k8s shim layer code for k8s, it depends on `yunikorn-core` which encapsulates all the actual scheduling logic.
 By default, it handles all pods scheduling if pod's spec has field `schedulerName: yunikorn`.
 
-For detailed information on how to build the overall scheduler please see the [build document](https://github.com/apache/incubator-yunikorn-core/blob/master/docs/developer-guide.md) in the `yunikorn-core`.
+For detailed information on how to build the overall scheduler please see the [build document](https://github.com/apache/incubator-yunikorn-site/blob/master/docs/developer_guide/build.md) in the `yunikorn-site`.
 
 ## K8s-shim component build
 This component build should only be used for development builds.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ YuniKorn scheduler shim for kubernetes is a customized k8s scheduler, it can be 
 This project contains the k8s shim layer code for k8s, it depends on `yunikorn-core` which encapsulates all the actual scheduling logic.
 By default, it handles all pods scheduling if pod's spec has field `schedulerName: yunikorn`.
 
-For detailed information on how to build the overall scheduler please see the [build document](https://github.com/apache/incubator-yunikorn-site/blob/master/docs/developer_guide/build.md) in the `yunikorn-site`.
+For detailed information on how to build the overall scheduler please see the [build document](https://yunikorn.apache.org/docs/next/developer_guide/build) in the `yunikorn-site`.
 
 ## K8s-shim component build
 This component build should only be used for development builds.


### PR DESCRIPTION
…-yunikorn-k8shim

### What is this PR for?
The related docs were moved to incubator-yunikorn-site repo and https://issues.apache.org/jira/browse/YUNIKORN-395 had cleaned up the old docs from incubator-yunikorn-core. Hence, current web link "https://github.com/apache/incubator-yunikorn-core/blob/master/docs/developer-guide.md" is not available. It should be replaced with "https://github.com/apache/incubator-yunikorn-site/blob/master/docs/developer_guide/build.md"

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-754

### How should this be tested?
test link manually (https://github.com/chia7712/incubator-yunikorn-k8shim/tree/YUNIKORN-754)

### Screenshots (if appropriate)
no

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
