### PR TITLE
[YUNIKORN-757] Discover daemonset pods and tag with ignoreUnschedulableNodes attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ go 1.12
 require (
 	github.com/GoogleCloudPlatform/spark-on-k8s-operator v0.0.0-20201215015655-2e8b733f5ad0
 	github.com/apache/incubator-yunikorn-core v0.11.0
-	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.0
+	github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20210723194917-606421b15601
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/mux v1.7.3
 	github.com/looplab/fsm v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -49,10 +49,13 @@ github.com/apache/incubator-yunikorn-core v0.0.0-20210610162734-22a46becdfa0 h1:
 github.com/apache/incubator-yunikorn-core v0.0.0-20210610162734-22a46becdfa0/go.mod h1:2Y9S04fXZv3Gidxs9BhkE9tKtmoMQ43JgrnopNfDsA8=
 github.com/apache/incubator-yunikorn-core v0.11.0 h1:HOHRdDZ/mEWymFsk/uv3BAI7hD3g911DnzmuFIeerhE=
 github.com/apache/incubator-yunikorn-core v0.11.0/go.mod h1:69pVGeIpUKXxCyByIvPxWjW15vYB14Yxtm+L4HCYC2g=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.0.0-20210723194917-606421b15601/go.mod h1:rcxZj0JQxYrdYKWckgpZDasyyjsBcWtOz68hj13WYOU=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20210603182012-da24a8edf1ce h1:zh0+0q39P39q8RJn9exdeXdjRkC656JrVPYbDkJKyxs=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.9.1-0.20210603182012-da24a8edf1ce/go.mod h1:rcxZj0JQxYrdYKWckgpZDasyyjsBcWtOz68hj13WYOU=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.11.0 h1:nm6AQGbCaFHKJEKuzwpVwIAtxe+qbbiUstFQr8Bn7mw=
 github.com/apache/incubator-yunikorn-scheduler-interface v0.11.0/go.mod h1:rcxZj0JQxYrdYKWckgpZDasyyjsBcWtOz68hj13WYOU=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20210723194917-606421b15601 h1:iS/h0ZaJMtuWSf8IIQUDT3X0IDkTpi98qIWC7NHCYjE=
+github.com/apache/incubator-yunikorn-scheduler-interface v0.11.1-0.20210723194917-606421b15601/go.mod h1:rcxZj0JQxYrdYKWckgpZDasyyjsBcWtOz68hj13WYOU=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -50,6 +50,9 @@ const SparkLabelRoleDriver = "driver"
 const DefaultConfigMapName = "yunikorn-configs"
 const SchedulerName = "yunikorn"
 
+// OwnerReferences
+const DaemonSetType = "DaemonSet"
+
 // Application crd
 const AppManagerHandlerName = "yunikorn-app"
 

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -37,7 +37,7 @@ func CreateTagsForTask(pod *v1.Pod) map[string]string {
 	owners := pod.GetOwnerReferences()
 	if len(owners) > 0 {
 		for _, value := range owners {
-			if value.Kind == "DaemonSet" {
+			if value.Kind == constants.DaemonSetType {
 				tags[common.DomainYuniKorn+common.KeyIgnoreUnschedulable] = "true"
 			}
 		}

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -30,10 +30,18 @@ import (
 func CreateTagsForTask(pod *v1.Pod) map[string]string {
 	metaPrefix := common.DomainK8s + common.GroupMeta
 	tags := map[string]string{
-		metaPrefix + common.KeyNamespace: pod.Namespace,
-		metaPrefix + common.KeyPodName:   pod.Name,
+		metaPrefix + common.KeyNamespace:                      pod.Namespace,
+		metaPrefix + common.KeyPodName:                        pod.Name,
+		common.DomainYuniKorn + common.KeyIgnoreUnschedulable: "false",
 	}
-
+	owners := pod.GetOwnerReferences()
+	if len(owners) > 0 {
+		for _, value := range owners {
+			if value.Kind == "DaemonSet" {
+				tags[common.DomainYuniKorn+common.KeyIgnoreUnschedulable] = "true"
+			}
+		}
+	}
 	// add Pod labels to Task tags
 	labelPrefix := common.DomainK8s + common.GroupLabel
 	for k, v := range pod.Labels {

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -120,7 +120,7 @@ func TestCreateTagsForTask(t *testing.T) {
 	metaPrefix := common.DomainK8s + common.GroupMeta
 	labelPrefix := common.DomainK8s + common.GroupLabel
 	// pod without ownerReference
-	result1 := createTagsForTask(pod)
+	result1 := CreateTagsForTask(pod)
 	assert.Equal(t, len(result1), 5)
 	assert.Equal(t, result1[metaPrefix+common.KeyNamespace], podNamespace)
 	assert.Equal(t, result1[metaPrefix+common.KeyPodName], podName1)
@@ -140,7 +140,7 @@ func TestCreateTagsForTask(t *testing.T) {
 		owner,
 	}
 	pod.SetOwnerReferences(refer)
-	result2 := createTagsForTask(pod)
+	result2 := CreateTagsForTask(pod)
 	assert.Equal(t, len(result2), 5)
 	assert.Equal(t, result2[metaPrefix+common.KeyNamespace], podNamespace)
 	assert.Equal(t, result2[metaPrefix+common.KeyPodName], podName2)
@@ -159,7 +159,7 @@ func TestCreateTagsForTask(t *testing.T) {
 		owner2,
 	}
 	pod.SetOwnerReferences(refer2)
-	result3 := createTagsForTask(pod)
+	result3 := CreateTagsForTask(pod)
 	assert.Equal(t, len(result3), 5)
 	assert.Equal(t, result3[common.DomainYuniKorn+common.KeyIgnoreUnschedulable], "false")
 }

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -96,3 +96,70 @@ func TestCreateUpdateRequestForTask(t *testing.T) {
 	assert.Equal(t, tags[common.DomainK8s+common.GroupLabel+"label1"], "val1")
 	assert.Equal(t, tags[common.DomainK8s+common.GroupLabel+"label2"], "val2")
 }
+
+func TestCreateTagsForTask(t *testing.T) {
+	podName1 := "test1"
+	podName2 := "test2"
+	podNamespace := "default"
+	labels := map[string]string{
+		"label1": "val1",
+		"label2": "val2",
+	}
+	pod := &v1.Pod{
+		TypeMeta: apis.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apis.ObjectMeta{
+			Name:      podName1,
+			UID:       "UID-00001",
+			Namespace: podNamespace,
+			Labels:    labels,
+		},
+	}
+	metaPrefix := common.DomainK8s + common.GroupMeta
+	labelPrefix := common.DomainK8s + common.GroupLabel
+	// pod without ownerReference
+	result1 := createTagsForTask(pod)
+	assert.Equal(t, len(result1), 5)
+	assert.Equal(t, result1[metaPrefix+common.KeyNamespace], podNamespace)
+	assert.Equal(t, result1[metaPrefix+common.KeyPodName], podName1)
+	assert.Equal(t, result1[common.DomainYuniKorn+common.KeyIgnoreUnschedulable], "false")
+	for k, v := range pod.Labels {
+		assert.Equal(t, result1[labelPrefix+k], v)
+	}
+	// pod with DaemonSet ownerReference
+	pod.Name = podName2
+	owner := apis.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "DaemonSet",
+		Name:       "DaemonSetPod",
+		UID:        "UID-001",
+	}
+	refer := []apis.OwnerReference{
+		owner,
+	}
+	pod.SetOwnerReferences(refer)
+	result2 := createTagsForTask(pod)
+	assert.Equal(t, len(result2), 5)
+	assert.Equal(t, result2[metaPrefix+common.KeyNamespace], podNamespace)
+	assert.Equal(t, result2[metaPrefix+common.KeyPodName], podName2)
+	assert.Equal(t, result2[common.DomainYuniKorn+common.KeyIgnoreUnschedulable], "true")
+	for k, v := range pod.Labels {
+		assert.Equal(t, result2[labelPrefix+k], v)
+	}
+	// pod with ReplicaSet ownerReference
+	owner2 := apis.OwnerReference{
+		APIVersion: "v1",
+		Kind:       "ReplicaSet",
+		Name:       "ReplicaSetPod",
+		UID:        "UID-002",
+	}
+	refer2 := []apis.OwnerReference{
+		owner2,
+	}
+	pod.SetOwnerReferences(refer2)
+	result3 := createTagsForTask(pod)
+	assert.Equal(t, len(result3), 5)
+	assert.Equal(t, result3[common.DomainYuniKorn+common.KeyIgnoreUnschedulable], "false")
+}


### PR DESCRIPTION
### What is this PR for?
 Add new `allocationTags` named `yunikorn.apache.org/ignoreUnschedulableNodes`.
if the pod  belongs to DaemonSet, the `yunikorn.apache.org/ignoreUnschedulableNodes` should be `true`.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-757

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
