### PR TITLE
[YUNIKORN-766] driver/executor get hang occasionally if the applicati…

### DIFF
--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -83,7 +83,6 @@ func GetQueueNameFromPod(pod *v1.Pod) string {
 }
 
 func GetApplicationIDFromPod(pod *v1.Pod) (string, error) {
-
 	// application ID can be defined in annotations
 	if value, found := pod.Annotations[constants.AnnotationApplicationID]; found {
 		return value, nil

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -83,24 +83,22 @@ func GetQueueNameFromPod(pod *v1.Pod) string {
 }
 
 func GetApplicationIDFromPod(pod *v1.Pod) (string, error) {
+
 	// application ID can be defined in annotations
-	for name, value := range pod.Annotations {
-		if name == constants.AnnotationApplicationID {
-			return value, nil
-		}
+	if value, found := pod.Annotations[constants.AnnotationApplicationID]; found {
+		return value, nil
 	}
 
 	// application ID can be defined in labels
-	for name, value := range pod.Labels {
-		// application ID can be defined as a label
-		if name == constants.LabelApplicationID {
-			return value, nil
-		}
+	if value, found := pod.Labels[constants.LabelApplicationID]; found {
+		fmt.Printf("[CHIA] name: %+v value: %+v\n", constants.LabelApplicationID, value)
+		return value, nil
+	}
 
-		// if a pod for spark already provided appID, reuse it
-		if name == constants.SparkLabelAppID {
-			return value, nil
-		}
+	// if a pod for spark already provided appID, reuse it
+	if value, found := pod.Labels[constants.SparkLabelAppID]; found {
+		fmt.Printf("[CHIA] name: %+v value: %+v\n", constants.SparkLabelAppID, value)
+		return value, nil
 	}
 
 	return "", fmt.Errorf("unable to retrieve application ID from pod spec, %s",

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -91,13 +91,11 @@ func GetApplicationIDFromPod(pod *v1.Pod) (string, error) {
 
 	// application ID can be defined in labels
 	if value, found := pod.Labels[constants.LabelApplicationID]; found {
-		fmt.Printf("[CHIA] name: %+v value: %+v\n", constants.LabelApplicationID, value)
 		return value, nil
 	}
 
 	// if a pod for spark already provided appID, reuse it
 	if value, found := pod.Labels[constants.SparkLabelAppID]; found {
-		fmt.Printf("[CHIA] name: %+v value: %+v\n", constants.SparkLabelAppID, value)
 		return value, nil
 	}
 

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -319,7 +319,7 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 		{"No AppID defined", &v1.Pod{}, true, ""},
 		{"Spark AppID defined in spark app selector and label", &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      map[string]string{constants.SparkLabelAppID: appIDInSelector, constants.LabelApplicationID: appIDInLabel},
+				Labels: map[string]string{constants.SparkLabelAppID: appIDInSelector, constants.LabelApplicationID: appIDInLabel},
 			},
 		}, false, appIDInLabel},
 	}

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -317,6 +317,11 @@ func TestGetApplicationIDFromPod(t *testing.T) {
 			},
 		}, false, sparkIDInAnnotation},
 		{"No AppID defined", &v1.Pod{}, true, ""},
+		{"Spark AppID defined in spark app selector and label", &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{constants.SparkLabelAppID: appIDInSelector, constants.LabelApplicationID: appIDInLabel},
+			},
+		}, false, appIDInLabel},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
…onId is defined

### What is this PR for?
The code used to get applicationId is shown below.
```go
// application ID can be defined in labels
for name, value := range pod.Labels {
// application ID can be defined as a label
if name == constants.LabelApplicationID
{ return value, nil }

// if a pod for spark already provided appID, reuse it
if name == constants.SparkLabelAppID { return value, nil }
}
```
The iteration order is random so it could get application id from 'spark-app-selector' rather than `applicationId` (even though `applicationId` is defined by users)


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-766

### How should this be tested?
`TestGetApplicationIDFromPod`

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
