### PR TITLE
[YUNIKORN-770] Remove unnecessary DEBUG log while removing a pod from the cache

### DIFF
--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -245,12 +245,14 @@ func (cache *SchedulerCache) RemovePod(pod *v1.Pod) error {
 }
 
 func (cache *SchedulerCache) removePod(pod *v1.Pod) error {
-	n, ok := cache.nodesMap[pod.Spec.NodeName]
-	if !ok {
-		return fmt.Errorf("node %v is not found", pod.Spec.NodeName)
-	}
-	if err := n.RemovePod(pod); err != nil {
-		return err
+	if pod.Spec.NodeName != "" {
+		n, ok := cache.nodesMap[pod.Spec.NodeName]
+		if !ok {
+			return fmt.Errorf("node %v is not found", pod.Spec.NodeName)
+		}
+		if err := n.RemovePod(pod); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/cache/external/scheduler_cache_test.go
+++ b/pkg/cache/external/scheduler_cache_test.go
@@ -103,6 +103,14 @@ func TestAssignedPod(t *testing.T) {
 	}
 }
 
+func TestRemovePodWithoutNodeName(t *testing.T) {
+	cache := NewSchedulerCache(client.NewMockedAPIProvider().GetAPIs())
+	err := cache.removePod(&v1.Pod{
+		Spec: v1.PodSpec{},
+	})
+	assert.NilError(t, err, "It should be ok to remove a pod having empty node name")
+}
+
 // this test verifies that no matter which comes first, pod or node,
 // the cache should be updated correctly to contain the correct references
 // for unassigned pod, it will not be stored in the cached node.


### PR DESCRIPTION
### What is this PR for?
```go
	n, ok := cache.nodesMap[pod.Spec.NodeName]
	if !ok {
		return fmt.Errorf("node %v is not found", pod.Spec.NodeName)
	}
	if err := n.RemovePod(pod); err != nil {
		return err
	}
```
It can causes DEBUG log("node  is not found") if node name is an empty string. For example: the pod status is updated (according to outstanding requests) before it is assumed to be run on a node.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-770

### How should this be tested?
`TestRemovePodWithoutNodeName`

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
