### PR TITLE
[YUNIKORN-771] make license-check fix for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,25 @@ lint:
 	$${lintBin} run --new-from-rev=$${headSHA}
 
 .PHONY: license-check
+# This is a bit convoluted but using a recursive grep on linux fails to write anything when run
+# from the Makefile. That caused the pull-request license check run from the github action to
+# always pass. The syntax for find is slightly different too but that at least works in a similar
+# way on both Mac and Linux. Excluding all .git* files from the checks.
+OS := $(shell uname -s)
 license-check:
-	@echo "checking license header"
-	@licRes=$$(grep -Lr --include=*.{go,sh,md,yaml,yml,mod} "Licensed to the Apache Software Foundation" .) ; \
-	if [ -n "$${licRes}" ]; then \
-		echo "following files have incorrect license header:\n$${licRes}" ; \
+	@echo "checking license headers:"
+ifeq (Darwin,$(OS))
+	$(shell find -E . -not -path "./.git*" -regex ".*\.(go|sh|md|yaml|yml|mod)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
+else
+	$(shell find . -not -path "./.git*" -regex ".*\.\(go\|sh\|md\|yaml\|yml\|mod\)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES)
+endif
+	@if [ -s LICRES ]; then \
+		echo "following files are missing license header:" ; \
+		cat LICRES ; \
+		rm -f LICRES ; \
 		exit 1; \
-	fi
+	fi ; \
+	rm -f LICRES
 
 .PHONY: run
 run: build


### PR DESCRIPTION
### What is this PR for?
The license check run as part of the PR workflow always passes when run on linux.
The recursive grep redirect to a variable does not work.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-771

### How should this be tested?
NA