### PR TITLE
[YUNIKORN-703] Reduce scheduler recovery timeout and terminate failed container

### DIFF
--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -145,6 +146,7 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
+	os.Exit(1)
 }
 
 func (ss *KubernetesShim) triggerSchedulerStateRecovery(e *fsm.Event) {
@@ -162,7 +164,7 @@ func (ss *KubernetesShim) recoverSchedulerState(e *fsm.Event) {
 		// this step, we collect all the existing allocated pods from api-server,
 		// identify the scheduling identity (aka applicationInfo) from the pod,
 		// and then add these applications to the scheduler.
-		if err := ss.appManager.WaitForRecovery(3 * time.Minute); err != nil {
+		if err := ss.appManager.WaitForRecovery(30 * time.Second); err != nil {
 			// failed
 			log.Logger().Error("scheduler recovery failed", zap.Error(err))
 			dispatcher.Dispatch(ShimSchedulerEvent{
@@ -181,7 +183,7 @@ func (ss *KubernetesShim) recoverSchedulerState(e *fsm.Event) {
 				recoverableAppManagers = append(recoverableAppManagers, m)
 			}
 		}
-		if err := ss.context.WaitForRecovery(recoverableAppManagers, 3*time.Minute); err != nil {
+		if err := ss.context.WaitForRecovery(recoverableAppManagers, 30*time.Second); err != nil {
 			// failed
 			log.Logger().Error("scheduler recovery failed", zap.Error(err))
 			dispatcher.Dispatch(ShimSchedulerEvent{

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -146,7 +146,7 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
-	if !conf.GetSchedulerConf().TestMode {
+	if !conf.GetSchedulerConf().IsTestMode() {
 		os.Exit(1)
 	}
 }

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -146,7 +146,9 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
-	os.Exit(1)
+	if !conf.GetSchedulerConf().TestMode {
+		os.Exit(1)
+	}
 }
 
 func (ss *KubernetesShim) triggerSchedulerStateRecovery(e *fsm.Event) {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -19,7 +19,6 @@
 package main
 
 import (
-	"os"
 	"sync"
 	"time"
 
@@ -146,9 +145,6 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
-	if !conf.GetSchedulerConf().IsTestMode() {
-		os.Exit(1)
-	}
 }
 
 func (ss *KubernetesShim) triggerSchedulerStateRecovery(e *fsm.Event) {


### PR DESCRIPTION
### What is this PR for?

Context:
YuniKorn scheduler restart failed multiple times affecting our production workload. 
During recovery no nodes are added to the scheduler cache.

Potential Causes: 
YuniKorn scheduler restart timeout is set very long (> 6min every time) while K8s API server responds with exponential backoffs. Failed scheduler container does not terminate.

Current Solutions: 
Reduce scheduler recovery timeout and terminate failed scheduler container

### What type of PR is it?
* [X] - Bug Fix
* [X] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-703

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
