### PR TITLE
[YUNIKORN-805] Fix race condition on the TestMode flag

### DIFF
--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -42,7 +42,7 @@ func GetRecorder() record.EventRecorder {
 		// note, the initiation of the event recorder requires on a workable Kubernetes client,
 		// in test mode we should skip this and just use a fake recorder instead.
 		configs := conf.GetSchedulerConf()
-		if !configs.TestMode {
+		if !configs.IsTestMode() {
 			k8sClient := client.NewKubeClient(configs.KubeConfig)
 			eventBroadcaster := record.NewBroadcaster()
 			eventBroadcaster.StartRecordingToSink(&v1.EventSinkImpl{

--- a/pkg/conf/schedulerconf.go
+++ b/pkg/conf/schedulerconf.go
@@ -83,6 +83,12 @@ func (conf *SchedulerConf) SetTestMode(testMode bool) {
 	conf.TestMode = testMode
 }
 
+func (conf *SchedulerConf) IsTestMode() bool {
+	conf.RLock()
+	defer conf.RUnlock()
+	return conf.TestMode
+}
+
 func (conf *SchedulerConf) GetSchedulingInterval() time.Duration {
 	conf.RLock()
 	defer conf.RUnlock()

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -145,6 +146,9 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
+	if !conf.GetSchedulerConf().IsTestMode() {
+		os.Exit(1)
+	}
 }
 
 func (ss *KubernetesShim) triggerSchedulerStateRecovery(e *fsm.Event) {
@@ -283,7 +287,6 @@ func (ss *KubernetesShim) run() {
 		log.Logger().Fatal("failed to start app manager", zap.Error(err))
 		ss.stop()
 	}
-
 }
 
 func (ss *KubernetesShim) enterState(event *fsm.Event) {

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -146,7 +146,8 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
-	if !conf.GetSchedulerConf().IsTestMode() {
+	// testmode will be true when mock scheduler intailize
+	if configured := conf.GetSchedulerConf(); !configured.IsTestMode() {
 		os.Exit(1)
 	}
 }

--- a/pkg/shim/scheduler.go
+++ b/pkg/shim/scheduler.go
@@ -147,7 +147,7 @@ func (ss *KubernetesShim) register(e *fsm.Event) {
 func (ss *KubernetesShim) handleSchedulerFailure(e *fsm.Event) {
 	ss.stop()
 	// testmode will be true when mock scheduler intailize
-	if configured := conf.GetSchedulerConf(); !configured.IsTestMode() {
+	if !conf.GetSchedulerConf().IsTestMode() {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
### What is this PR for?
Avoid data race which R/W in same time.
Add getting TestMode in config object with R lock

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-805

### How should this be tested?
make test with Makefile

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
