### PR TITLE
[YUNIKORN-858] Pass node labels as node attributes for node sorting

### DIFF
--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -38,6 +38,7 @@ import (
 type SchedulerNode struct {
 	name                string
 	uid                 string
+	labels              string
 	capacity            *si.Resource
 	occupied            *si.Resource
 	schedulable         bool
@@ -47,11 +48,12 @@ type SchedulerNode struct {
 	lock                *sync.RWMutex
 }
 
-func newSchedulerNode(nodeName string, nodeUID string,
+func newSchedulerNode(nodeName string, nodeUID string, nodeLabels string,
 	nodeResource *si.Resource, schedulerAPI api.SchedulerAPI, schedulable bool) *SchedulerNode {
 	schedulerNode := &SchedulerNode{
 		name:         nodeName,
 		uid:          nodeUID,
+		labels:       nodeLabels,
 		capacity:     nodeResource,
 		occupied:     common.NewResourceBuilder().Build(),
 		schedulerAPI: schedulerAPI,
@@ -156,8 +158,9 @@ func (n *SchedulerNode) handleNodeRecovery(event *fsm.Event) {
 				SchedulableResource: n.capacity,
 				OccupiedResource:    n.occupied,
 				Attributes: map[string]string{
-					constants.DefaultNodeAttributeHostNameKey: n.name,
-					constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
+					constants.DefaultNodeAttributeHostNameKey:   n.name,
+					constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
+					constants.DefaultNodeAttributeNodeLabelsKey: n.labels,
 				},
 				ExistingAllocations: n.existingAllocations,
 			},
@@ -184,8 +187,9 @@ func (n *SchedulerNode) handleDrainNode(event *fsm.Event) {
 				NodeID: n.name,
 				Action: si.UpdateNodeInfo_DRAIN_NODE,
 				Attributes: map[string]string{
-					constants.DefaultNodeAttributeHostNameKey: n.name,
-					constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
+					constants.DefaultNodeAttributeHostNameKey:   n.name,
+					constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
+					constants.DefaultNodeAttributeNodeLabelsKey: n.labels,
 				},
 			},
 		},
@@ -211,8 +215,9 @@ func (n *SchedulerNode) handleRestoreNode(event *fsm.Event) {
 				NodeID: n.name,
 				Action: si.UpdateNodeInfo_DRAIN_TO_SCHEDULABLE,
 				Attributes: map[string]string{
-					constants.DefaultNodeAttributeHostNameKey: n.name,
-					constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
+					constants.DefaultNodeAttributeHostNameKey:   n.name,
+					constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
+					constants.DefaultNodeAttributeNodeLabelsKey: n.labels,
 				},
 			},
 		},

--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -67,6 +67,6 @@ func NewTestSchedulerNode() *SchedulerNode {
 		AddResource(constants.Memory, 1).
 		AddResource(constants.CPU, 1).
 		Build()
-	node := newSchedulerNode("host001", "UID001", r1, api, false)
+	node := newSchedulerNode("host001", "UID001", "{\"label1\":\"key1\",\"label2\":\"key2\"}", r1, api, false)
 	return node
 }

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 
@@ -100,10 +101,18 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 
 	// add node to nodes map
 	if _, ok := nc.nodesMap[node.Name]; !ok {
+		nodeLabels, err := json.Marshal(node.Labels)
+		if err != nil {
+			log.Logger().Error("failed to marshall node labels to json", zap.Error(err))
+			return
+		}
+
 		log.Logger().Info("adding node to context",
 			zap.String("nodeName", node.Name),
+			zap.String("nodeLabels", string(nodeLabels)),
 			zap.Bool("schedulable", !node.Spec.Unschedulable))
-		newNode := newSchedulerNode(node.Name, string(node.UID),
+
+		newNode := newSchedulerNode(node.Name, string(node.UID), string(nodeLabels),
 			common.GetNodeResource(&node.Status), nc.proxy, !node.Spec.Unschedulable)
 		nc.nodesMap[node.Name] = newNode
 	}

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -101,9 +101,12 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 
 	// add node to nodes map
 	if _, ok := nc.nodesMap[node.Name]; !ok {
-		nodeLabels, err := json.Marshal(node.Labels)
+
+		var nodeLabels []byte
+		nodeLabels, err := json.Marshal(node.Labels) // A nil pointer encodes as the "null" JSON value.
 		if err != nil {
 			log.Logger().Error("failed to marshall node labels to json", zap.Error(err))
+			nodeLabels = make([]byte, 0)
 		}
 
 		log.Logger().Info("adding node to context",

--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -104,7 +104,6 @@ func (nc *schedulerNodes) addAndReportNode(node *v1.Node, reportNode bool) {
 		nodeLabels, err := json.Marshal(node.Labels)
 		if err != nil {
 			log.Logger().Error("failed to marshall node labels to json", zap.Error(err))
-			return
 		}
 
 		log.Logger().Info("adding node to context",

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -21,6 +21,7 @@ package constants
 // Cluster
 const DefaultNodeAttributeHostNameKey = "si.io/hostname"
 const DefaultNodeAttributeRackNameKey = "si.io/rackname"
+const DefaultNodeAttributeNodeLabelsKey = "si.io/nodelabels"
 const DefaultRackName = "/rack-default"
 
 // Application


### PR DESCRIPTION
### What is this PR for?

Node labels need to be passed into "YuniKorn Core" via "YuniKorn Scheduler Interface" (YK SI) as node attributes. It then can be considered during node sorting.

In particular, to keep the protobuf value type of node attributes still string, we plan to marshal node labels (map[string]string) into a JSON string before passing to YK SI.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [X] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-858

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
