### PR TITLE
[YUNIKORN-508] fix log collection path

### DIFF
--- a/test/e2e/framework/configmanager/config.go
+++ b/test/e2e/framework/configmanager/config.go
@@ -23,7 +23,7 @@ import (
 	"time"
 )
 
-// YuniKornTestConfigType holds all of the configurable elements of the testsuite
+// YuniKornTestConfigType holds all configurable elements of the testsuite
 type YuniKornTestConfigType struct {
 	JSONLogs    bool
 	LogLevel    string
@@ -44,23 +44,23 @@ var YuniKornTestConfig = YuniKornTestConfigType{}
 // ParseFlags parses commandline flags relevant to testing.
 func (c *YuniKornTestConfigType) ParseFlags() {
 	flag.BoolVar(&c.JSONLogs, "json-logs-enabled", false,
-		"Enables logging in json format")
+		"Enable json log format")
 	flag.StringVar(&c.LogLevel, "log-level", "debug",
-		"log level(debug|info|error|critical")
+		"log level one of: debug|info|error|critical")
 	flag.StringVar(&c.KubeConfig, "kube-config", "~/.kube/config",
 		"Kubeconfig to be used for tests")
 	flag.StringVar(&c.LogFile, "log-file", "test-output.log",
-		"Log location")
+		"Log filename")
 	flag.DurationVar(&c.Timeout, "timeout", 24*time.Hour,
 		"Specifies timeout for test run")
 	flag.StringVar(&c.YkNamespace, "yk-namespace", "yunikorn",
-		"K8s Namespace in which YuniKorn service deployed")
+		"K8s Namespace in which YuniKorn service is deployed")
 	flag.StringVar(&c.YkHost, "yk-host", DefaultYuniKornHost,
 		"Hostname/IP of YuniKorn service")
 	flag.StringVar(&c.YkPort, "yk-port", DefaultYuniKornPort,
 		"External Port of YuniKorn service")
 	flag.StringVar(&c.YkScheme, "yk-scheme", DefaultYuniKornScheme,
-		"Scheme of YuniKron Service")
-	flag.StringVar(&c.LogDir, "log-dir", "/yunikorn-qe/test-results/target/failsafe-reports",
-		"Log location where the logs are stored")
+		"Scheme of YuniKorn web service")
+	flag.StringVar(&c.LogDir, "log-dir", "/tmp/e2e-test-reports",
+		"Directory for test log reports")
 }


### PR DESCRIPTION
### What is this PR for?
The e2e tests generate a log for analysis. The log directory is created
as part of the test run. The default path set in the code must be a
creatable or pre-existing path.
If the directory exists it is re-used. Files inside the directory will
be truncated and re-written when needed.
Changing default to: /tmp/e2e-test-reports

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
YUNIKORN-508 Fix/remove log collection error from upstream runs

### How should this be tested?
NA, removes messages about non existing directories in e2e test