### PR TITLE
[YUNIKORN-971] Implement YuniKorn as a Kubernetes scheduler plugin.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ endif
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 BINARY=k8s_yunikorn_scheduler
+PLUGIN_BINARY=kube-scheduler
 OUTPUT=_output
 RELEASE_BIN_DIR=${OUTPUT}/bin
 ADMISSION_CONTROLLER_BIN_DIR=${OUTPUT}/admission-controllers/
@@ -124,6 +125,23 @@ run: build
 	-clusterId=mycluster -clusterVersion=${VERSION} -policyGroup=queues \
 	-logEncoding=console -logLevel=-1
 
+.PHONY: run_plugin
+run_plugin: build_plugin
+	@echo "running scheduler plugin locally"
+	@cp ${LOCAL_CONF}/${CONF_FILE} ${RELEASE_BIN_DIR}
+	./scripts/plugin-conf-gen.sh $(KUBECONFIG) ${RELEASE_BIN_DIR}
+	cd ${RELEASE_BIN_DIR} && \
+	  ./${PLUGIN_BINARY} \
+	    --address=0.0.0.0 \
+	    --leader-elect=false \
+	    --config=scheduler-config.yaml \
+	    -v=2 \
+	    --yk-scheduler-name=yunikorn \
+	    --yk-kube-config=$(KUBECONFIG) \
+	    --yk-cluster-id=yk \
+	    --yk-scheduling-interval=1s \
+	    --yk-log-level=1
+
 # Create output directories
 .PHONY: init
 init:
@@ -136,8 +154,16 @@ build: init
 	@echo "building scheduler binary"
 	go build -o=${RELEASE_BIN_DIR}/${BINARY} -race -ldflags \
 	'-X main.version=${VERSION} -X main.date=${DATE}' \
-    ./pkg/shim/
+	./pkg/cmd/shim/
 	@chmod +x ${RELEASE_BIN_DIR}/${BINARY}
+
+.PHONY: build_plugin
+build_plugin: init
+	@echo "building scheduler plugin"
+	go build -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -race -ldflags \
+	'-X main.version=${VERSION} -X main.date=${DATE}' \
+	./pkg/cmd/schedulerplugin/
+	@chmod +x ${RELEASE_BIN_DIR}/${PLUGIN_BINARY}
 
 # Build scheduler binary in a production ready version
 .PHONY: scheduler
@@ -147,14 +173,23 @@ scheduler: init
 	go build -a -o=${RELEASE_BIN_DIR}/${BINARY} -ldflags \
 	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
 	-tags netgo -installsuffix netgo \
-	./pkg/shim/
+	./pkg/cmd/shim/
 
+# Build plugin binary in a production ready version
+.PHONY: plugin
+plugin: init
+	@echo "building binary for scheduler docker image"
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+	go build -a -o=${RELEASE_BIN_DIR}/${PLUGIN_BINARY} -ldflags \
+	'-extldflags "-static" -X main.version=${VERSION} -X main.date=${DATE}' \
+	-tags netgo -installsuffix netgo \
+	./pkg/cmd/schedulerplugin/
+	
 # Build a scheduler image based on the production ready version
 .PHONY: sched_image
 sched_image: scheduler
 	@echo "building scheduler docker image"
 	@cp ${RELEASE_BIN_DIR}/${BINARY} ./deployments/image/configmap
-	@mkdir -p ./deployments/image/configmap/admission-controller-init-scripts
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/configmap/Dockerfile
 	docker build ./deployments/image/configmap -t ${REGISTRY}/yunikorn:scheduler-${VERSION} \
 	--label "yunikorn-core-revision=${CORE_SHA}" \
@@ -164,7 +199,26 @@ sched_image: scheduler
 	--label "Version=${VERSION}"
 	@mv -f ./deployments/image/configmap/Dockerfile.bkp ./deployments/image/configmap/Dockerfile
 	@rm -f ./deployments/image/configmap/${BINARY}
-	@rm -rf ./deployments/image/configmap/admission-controller-init-scripts/
+
+# Build a plugin image based on the production ready version
+.PHONY: plugin_image
+plugin_image: plugin
+	@echo "building plugin docker image"
+	@cp ${RELEASE_BIN_DIR}/${PLUGIN_BINARY} ./deployments/image/plugin
+	@cp conf/scheduler-config.yaml ./deployments/image/plugin/scheduler-config.yaml
+	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/plugin/Dockerfile
+	@coreSHA=$$(go list -m "github.com/apache/incubator-yunikorn-core" | cut -d "-" -f5) ; \
+	siSHA=$$(go list -m "github.com/apache/incubator-yunikorn-scheduler-interface" | cut -d "-" -f6) ; \
+	shimSHA=$$(git rev-parse --short=12 HEAD) ; \
+	docker build ./deployments/image/plugin -t ${REGISTRY}/yunikorn:scheduler-plugin-${VERSION} \
+	--label "yunikorn-core-revision=$${coreSHA}" \
+	--label "yunikorn-scheduler-interface-revision=$${siSHA}" \
+	--label "yunikorn-k8shim-revision=$${shimSHA}" \
+	--label "BuildTimeStamp=${DATE}" \
+	--label "Version=${VERSION}"
+	@mv -f ./deployments/image/plugin/Dockerfile.bkp ./deployments/image/plugin/Dockerfile
+	@rm -f ./deployments/image/plugin/${PLUGIN_BINARY}
+	@rm -f ./deployments/image/plugin/scheduler-config.yaml
 
 # Build admission controller binary in a production ready version
 .PHONY: admission
@@ -217,7 +271,7 @@ simulation_image: simulation
 	
 # Build all images based on the production ready version
 .PHONY: image
-image: sched_image adm_image
+image: sched_image plugin_image adm_image
 
 .PHONY: push
 push: image

--- a/Makefile
+++ b/Makefile
@@ -207,13 +207,10 @@ plugin_image: plugin
 	@cp ${RELEASE_BIN_DIR}/${PLUGIN_BINARY} ./deployments/image/plugin
 	@cp conf/scheduler-config.yaml ./deployments/image/plugin/scheduler-config.yaml
 	@sed -i'.bkp' 's/clusterVersion=.*"/clusterVersion=${VERSION}"/' deployments/image/plugin/Dockerfile
-	@coreSHA=$$(go list -m "github.com/apache/incubator-yunikorn-core" | cut -d "-" -f5) ; \
-	siSHA=$$(go list -m "github.com/apache/incubator-yunikorn-scheduler-interface" | cut -d "-" -f6) ; \
-	shimSHA=$$(git rev-parse --short=12 HEAD) ; \
 	docker build ./deployments/image/plugin -t ${REGISTRY}/yunikorn:scheduler-plugin-${VERSION} \
-	--label "yunikorn-core-revision=$${coreSHA}" \
-	--label "yunikorn-scheduler-interface-revision=$${siSHA}" \
-	--label "yunikorn-k8shim-revision=$${shimSHA}" \
+	--label "yunikorn-core-revision=${CORE_SHA}" \
+	--label "yunikorn-scheduler-interface-revision=${SI_SHA}" \
+	--label "yunikorn-k8shim-revision=${SHIM_SHA}" \
 	--label "BuildTimeStamp=${DATE}" \
 	--label "Version=${VERSION}"
 	@mv -f ./deployments/image/plugin/Dockerfile.bkp ./deployments/image/plugin/Dockerfile

--- a/conf/scheduler-config.yaml
+++ b/conf/scheduler-config.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+profiles:
+  - schedulerName: yunikorn
+    plugins:
+      preFilter:
+        enabled:
+        - name: YuniKornPlugin
+      filter:
+        enabled:
+        - name: YuniKornPlugin
+      postBind:
+        enabled:
+        - name: YuniKornPlugin

--- a/deployments/image/plugin/Dockerfile
+++ b/deployments/image/plugin/Dockerfile
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:latest
+
+# scheduler binary
+ADD kube-scheduler /bin/kube-scheduler
+ADD scheduler-config.yaml /bin/scheduler-config.yaml
+WORKDIR /bin
+ENV CLUSTER_ID "mycluster"
+ENV CLUSTER_VERSION "latest"
+ENV POLICY_GROUP "queues"
+ENV SCHEDULING_INTERVAL "1s"
+ENV LOG_LEVEL "0"
+ENV LOG_ENCODING "console"
+ENV EVENT_CHANNEL_CAPACITY "1048576"
+ENV DISPATCHER_TIMEOUT "300s"
+ENV KUBE_CLIENT_QPS "1000"
+ENV KUBE_CLIENT_BURST "1000"
+ENV OPERATOR_PLUGINS "general"
+ENV ENABLE_CONFIG_HOT_REFRESH "true"
+ENV DISABLE_GANG_SCHEDULING "false"
+ENV USER_LABEL_KEY "yunikorn.apache.org/username"
+ENV ADDRESS "0.0.0.0"
+ENV LEADER_ELECT "false"
+ENV SCHEDULER_CONFIG "scheduler-config.yaml"
+ENV VERBOSITY "2"
+ENV SCHEDULER_NAME "yunikorn"
+
+ENTRYPOINT ["/bin/sh", "-c", "/bin/kube-scheduler \
+--address=\"${ADDRESS}\" \
+--leader-elect=\"${LEADER_ELECT}\" \
+--config=\"${SCHEDULER_CONFIG}\" \
+-v=\"${VERBOSITY}\" \
+--scheduler-name=\"${SCHEDULER_NAME}\" \
+--yk-cluster-id=\"${CLUSTER_ID}\" \
+--yk-cluster-version=\"${CLUSTER_VERSION}\" \
+--yk-policy-group=\"${POLICY_GROUP}\" \
+--yk-scheduling-interval=\"${SCHEDULING_INTERVAL}\" \
+--yk-log-level=\"${LOG_LEVEL}\" \
+--yk-log-encoding=\"${LOG_ENCODING}\" \
+--yk-event-channel-capacity=\"${EVENT_CHANNEL_CAPACITY}\" \
+--yk-dispatcher-timeout=\"${DISPATCHER_TIMEOUT}\" \
+--yk-kube-qps=\"${KUBE_CLIENT_QPS}\" \
+--yk-kube-burst=\"${KUBE_CLIENT_BURST}\" \
+--yk-enable-config-hot-refresh=\"${ENABLE_CONFIG_HOT_REFRESH}\" \
+--yk-disable-gang-scheduling=\"${DISABLE_GANG_SCHEDULING}\" \
+--yk-user-label-key=\"${USER_LABEL_KEY}\" \
+--yk-scheduler-name=\"${SCHEDULER_NAME}\""]

--- a/deployments/scheduler/plugin.yaml
+++ b/deployments/scheduler/plugin.yaml
@@ -1,0 +1,185 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yunikorn-admin
+  namespace: yunikorn
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: yunikorn-rbac
+subjects:
+  - kind: ServiceAccount
+    name: yunikorn-admin
+    namespace: yunikorn
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yunikorn-configs
+  namespace: yunikorn
+  labels:
+    app: yunikorn
+data:
+  queues.yaml: |
+    partitions:
+      - name: default
+        nodesortpolicy:
+          type: fair
+        placementrules:
+          - name: tag
+            value: namespace
+            create: true
+        queues:
+          - name: root
+            submitacl: '*'
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: yunikorn-scheduler-plugin-configs
+  namespace: yunikorn
+  labels:
+    app: yunikorn
+data:
+  scheduler-config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta1
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles:
+      - schedulerName: yunikorn
+        plugins:
+          preFilter:
+            enabled:
+              - name: YuniKornPlugin
+          filter:
+            enabled:
+              - name: YuniKornPlugin
+          postBind:
+            enabled:
+              - name: YuniKornPlugin
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: yunikorn
+  name: yunikorn-scheduler
+  namespace: yunikorn
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: yunikorn
+  template:
+    metadata:
+      labels:
+        app: yunikorn
+        component: yunikorn-scheduler
+      name: yunikorn-scheduler
+    spec:
+      serviceAccountName: yunikorn-admin
+      containers:
+        - name: yunikorn-scheduler-k8s
+          image: apache/yunikorn:scheduler-plugin-latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http1
+              containerPort: 9080
+              protocol: TCP
+          env:
+            - name: NAMESPACE
+              value: "yunikorn"
+            - name: SCHEDULER_NAME
+              value: "yunikorn"
+            - name: SCHEDULER_CONFIG
+              value: "/etc/kubernetes/scheduler-config.yaml"
+          resources:
+            requests:
+              cpu: 1
+              memory: 1Gi
+            limits:
+              cpu: 4
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /etc/kubernetes
+              name: scheduler-config
+            - mountPath: /etc/yunikorn
+              name: quotamanager-config
+          livenessProbe:
+            httpGet:
+              path: /ws/v1/scheduler/healthcheck
+              port: 9080
+            initialDelaySeconds: 20
+            periodSeconds: 600
+            failureThreshold: 1
+        - name: yunikorn-scheduler-web
+          image: apache/yunikorn:web-latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http2
+              containerPort: 9889
+              protocol: TCP
+          resources:
+            requests:
+              memory: "100Mi"
+              cpu: "100m"
+            limits:
+              memory: "500Mi"
+              cpu: "200m"
+      volumes:
+        - name: scheduler-config
+          configMap:
+            name: yunikorn-scheduler-plugin-configs
+        - name: quotamanager-config
+          configMap:
+            name: yunikorn-configs
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: yunikorn-service
+  labels:
+    app: yunikorn-service
+  namespace: yunikorn
+spec:
+  ports:
+    - port: 9080
+      targetPort: http1
+      protocol: TCP
+      name: yunikorn-core
+    - port: 9889
+      targetPort: http2
+      protocol: TCP
+      name: yunikorn-service
+  selector:
+    app: yunikorn
+  type: LoadBalancer

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	github.com/looplab/fsm v0.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
+	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.13.0
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible
@@ -36,6 +38,7 @@ require (
 	k8s.io/apimachinery v0.20.11
 	k8s.io/apiserver v0.20.11
 	k8s.io/client-go v0.20.11
+	k8s.io/component-base v0.20.11
 	k8s.io/klog v1.0.0
 	k8s.io/kube-scheduler v0.20.11
 	k8s.io/kubernetes v1.20.11

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ contrib.go.opencensus.io/exporter/stackdriver v0.0.0-20180421005815-665cf5131b71
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v32.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v43.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
@@ -66,12 +67,15 @@ github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tT
 github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
 github.com/Microsoft/hcsshim v0.0.0-20190417211021-672e52e9209d/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/Microsoft/hcsshim v0.8.10-0.20200715222032-5eafd1556990/go.mod h1:ay/0dTb7NsG8QMDfsRfLHgZo/6xAJShLe1+ePPflihk=
+github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46 h1:lsxEuwrXEAokXB9qhlbKWPpo3KMLZQ5WB5WLQRW1uq0=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkFW6gg=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
@@ -214,6 +218,7 @@ github.com/elazarl/goproxy v0.0.0-20200421181703-e76ad31c14f6/go.mod h1:Ro8st/El
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 h1:dWB6v3RcOy03t/bUadywsbyrQwCqZeNIEX6M1OtSZOM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -262,11 +267,13 @@ github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.18.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
+github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
+github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
@@ -280,6 +287,7 @@ github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nA
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
+github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
@@ -289,6 +297,7 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
@@ -436,6 +445,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
@@ -493,6 +503,7 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -524,6 +535,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/moby/ipvs v1.0.1/go.mod h1:2pngiyseZbIKXNv7hsKj3O9UEz30c53MT9005gt2hxQ=
 github.com/moby/sys/mountinfo v0.1.3/go.mod h1:w2t2Avltqx8vE7gX5l+QiBKxODu2TX0+Syr3h52Tw4o=
+github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -538,6 +550,7 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/mrunalp/fileutils v0.0.0-20160930181131-4ee1cc9a8058/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/mrunalp/fileutils v0.0.0-20200520151820-abd8a0e76976/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -660,6 +673,7 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1 h1:KfztREH0tPxJJ+geloSLaAkaPkr4ki2Er5quFV1TDo4=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -855,6 +869,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180329131831-378d26f46672/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1068,6 +1083,7 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.37.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mcuadros/go-syslog.v2 v2.2.1/go.mod h1:l5LPIyOOyIdQquNg+oU6Z3524YwrcqEm0aKH+5zpt2U=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -141,7 +141,7 @@ func TestFailApplication(t *testing.T) {
 		defer rt.lock.Unlock()
 		rt.time++
 	}
-	events.SetRecorderForTest(mr)
+	events.SetRecorder(mr)
 	resources := make(map[v1.ResourceName]resource.Quantity)
 	containers := make([]v1.Container, 0)
 	containers = append(containers, v1.Container{
@@ -206,7 +206,7 @@ func TestFailApplication(t *testing.T) {
 	assertAppState(t, app2, events.States().Application.Failed, 3*time.Second)
 	assert.Equal(t, rt.time, int64(0))
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
+	events.SetRecorder(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
@@ -234,7 +234,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
 	// set Recorder to mocked type
 	mr := events.NewMockedRecorder()
-	events.SetRecorderForTest(mr)
+	events.SetRecorder(mr)
 	resources := make(map[v1.ResourceName]resource.Quantity)
 	containers := make([]v1.Container, 0)
 	containers = append(containers, v1.Container{
@@ -315,7 +315,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 	assert.Equal(t, newPod3.Status.Phase, v1.PodFailed, 3*time.Second)
 	assert.Equal(t, newPod3.Status.Reason, constants.ApplicationInsufficientResourcesFailure, 3*time.Second)
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
+	events.SetRecorder(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
@@ -343,7 +343,7 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
 	// set Recorder to mocked type
 	mr := events.NewMockedRecorder()
-	events.SetRecorderForTest(mr)
+	events.SetRecorder(mr)
 	resources := make(map[v1.ResourceName]resource.Quantity)
 	containers := make([]v1.Container, 0)
 	containers = append(containers, v1.Container{
@@ -416,7 +416,7 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 	assert.Equal(t, newPod2.Status.Phase, v1.PodFailed, 3*time.Second)
 	assert.Equal(t, newPod2.Status.Reason, constants.ApplicationRejectedFailure, 3*time.Second)
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
+	events.SetRecorder(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestReleaseAppAllocation(t *testing.T) {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -450,8 +450,8 @@ func (ctx *Context) AddPendingPodAllocation(podKey string, nodeID string) {
 	ctx.schedulerCache.AddPendingPodAllocation(podKey, nodeID)
 }
 
-func (ctx *Context) RemovePendingPodAllocation(podKey string) {
-	ctx.schedulerCache.RemovePendingPodAllocation(podKey)
+func (ctx *Context) RemovePodAllocation(podKey string) {
+	ctx.schedulerCache.RemovePodAllocation(podKey)
 }
 
 func (ctx *Context) GetPendingPodAllocation(podKey string) (nodeID string, ok bool) {
@@ -599,7 +599,7 @@ func (ctx *Context) RemoveApplication(appID string) error {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	if app, exist := ctx.applications[appID]; exist {
-		//get the non-terminated task alias
+		// get the non-terminated task alias
 		nonTerminatedTaskAlias := app.getNonTerminatedTaskAlias()
 		// check there are any non-terminated task or not
 		if len(nonTerminatedTaskAlias) > 0 {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -53,6 +53,7 @@ type Context struct {
 	schedulerCache *schedulercache.SchedulerCache // external cache
 	apiProvider    client.APIProvider             // apis to interact with api-server, scheduler-core, etc
 	predManager    predicates.PredicateManager    // K8s predicates
+	pluginMode     bool                           // true if we are configured as a scheduler plugin
 	lock           *sync.RWMutex                  // lock
 }
 
@@ -117,6 +118,14 @@ func (ctx *Context) AddSchedulingEventHandlers() {
 		UpdateFn: ctx.updateConfigMaps,
 		DeleteFn: ctx.deleteConfigMaps,
 	})
+}
+
+func (ctx *Context) IsPluginMode() bool {
+	return ctx.pluginMode
+}
+
+func (ctx *Context) SetPluginMode(pluginMode bool) {
+	ctx.pluginMode = pluginMode
 }
 
 func (ctx *Context) addNode(obj interface{}) {
@@ -435,6 +444,28 @@ func (ctx *Context) UpdateApplication(app *Application) {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
 	ctx.applications[app.applicationID] = app
+}
+
+func (ctx *Context) AddPendingPodAllocation(podKey string, nodeID string) {
+	ctx.schedulerCache.AddPendingPodAllocation(podKey, nodeID)
+}
+
+func (ctx *Context) RemovePendingPodAllocation(podKey string) {
+	ctx.schedulerCache.RemovePendingPodAllocation(podKey)
+}
+
+func (ctx *Context) GetPendingPodAllocation(podKey string) (nodeID string, ok bool) {
+	nodeID, ok = ctx.schedulerCache.GetPendingPodAllocation(podKey)
+	return nodeID, ok
+}
+
+func (ctx *Context) GetInProgressPodAllocation(podKey string) (nodeID string, ok bool) {
+	nodeID, ok = ctx.schedulerCache.GetInProgressPodAllocation(podKey)
+	return nodeID, ok
+}
+
+func (ctx *Context) StartPodAllocation(podKey string, nodeID string) bool {
+	return ctx.schedulerCache.StartPodAllocation(podKey, nodeID)
 }
 
 // inform the scheduler that the application is completed,

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -462,7 +462,7 @@ func TestHandleSubmitTaskEvent(t *testing.T) {
 		defer rt.lock.Unlock()
 		rt.time++
 	}
-	events.SetRecorderForTest(mr)
+	events.SetRecorder(mr)
 	resources := make(map[v1.ResourceName]resource.Quantity)
 	containers := make([]v1.Container, 0)
 	containers = append(containers, v1.Container{
@@ -521,7 +521,7 @@ func TestHandleSubmitTaskEvent(t *testing.T) {
 	assert.Equal(t, rt.time, int64(2))
 
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
+	events.SetRecorder(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {

--- a/pkg/client/apifactory.go
+++ b/pkg/client/apifactory.go
@@ -78,11 +78,8 @@ type APIFactory struct {
 	lock     *sync.RWMutex
 }
 
-func NewAPIFactory(scheduler api.SchedulerAPI, configs *conf.SchedulerConf, testMode bool) *APIFactory {
+func NewAPIFactory(scheduler api.SchedulerAPI, informerFactory informers.SharedInformerFactory, configs *conf.SchedulerConf, testMode bool) *APIFactory {
 	kubeClient := NewKubeClient(configs.KubeConfig)
-
-	// we have disabled re-sync to keep ourselves up-to-date
-	informerFactory := informers.NewSharedInformerFactory(kubeClient.GetClientSet(), 0)
 
 	// init informers
 	// volume informers are also used to get the Listers for the predicates

--- a/pkg/cmd/schedulerplugin/main.go
+++ b/pkg/cmd/schedulerplugin/main.go
@@ -1,0 +1,51 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"k8s.io/kubernetes/cmd/kube-scheduler/app"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/schedulerplugin"
+	pluginconf "github.com/apache/incubator-yunikorn-k8shim/pkg/schedulerplugin/conf"
+)
+
+var (
+	version string
+	date    string
+)
+
+func main() {
+	// override the default config handling when in plugin mode
+	conf.SetSchedulerConfFactory(pluginconf.NewSchedulerConf)
+
+	pluginconf.BuildVersion = version
+	pluginconf.BuildDate = date
+
+	command := app.NewSchedulerCommand(
+		app.WithPlugin(schedulerplugin.SchedulerPluginName, schedulerplugin.NewSchedulerPlugin))
+
+	pluginconf.InitCliFlagSet(command)
+
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/pkg/cmd/shim/main.go
+++ b/pkg/cmd/shim/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/shim"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/api"
 )
 
@@ -45,14 +46,14 @@ func main() {
 	serviceContext := entrypoint.StartAllServicesWithLogger(log.Logger(), log.GetZapConfigs())
 
 	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
-		ss := newShimScheduler(sa, conf.GetSchedulerConf())
-		ss.run()
+		ss := shim.NewShimScheduler(sa, conf.GetSchedulerConf())
+		ss.Run()
 
 		signalChan := make(chan os.Signal, 1)
 		signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 		for range signalChan {
 			log.Logger().Info("Shutdown signal received, exiting...")
-			ss.stop()
+			ss.Stop()
 			os.Exit(0)
 		}
 	}

--- a/pkg/common/events/recorder.go
+++ b/pkg/common/events/recorder.go
@@ -52,6 +52,13 @@ func GetRecorder() events.EventRecorder {
 	return eventRecorder
 }
 
+func SetRecorder(recorder events.EventRecorder) {
+	lock.Lock()
+	defer lock.Unlock()
+	eventRecorder = recorder
+	once.Do(func() {}) // make sure Do() doesn't fire elsewhere
+}
+
 func SetRecorderForTest(recorder events.EventRecorder) {
 	lock.Lock()
 	defer lock.Unlock()

--- a/pkg/schedulerplugin/conf/pluginconf.go
+++ b/pkg/schedulerplugin/conf/pluginconf.go
@@ -1,0 +1,197 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package conf
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/component-base/cli/flag"
+	"k8s.io/component-base/term"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
+)
+
+// default configuration options, can be overridden by command-line args
+const (
+	DefaultSchedulerName = "yunikorn"
+)
+
+var (
+	BuildVersion string
+	BuildDate    string
+)
+
+// command line argument names
+const (
+	ArgClusterID              = "yk-cluster-id"
+	ArgClusterVersion         = "yk-cluster-version"
+	ArgPolicyGroup            = "yk-policy-group"
+	ArgSchedulingInterval     = "yk-scheduling-interval"
+	ArgKubeConfig             = "yk-kube-config"
+	ArgLogLevel               = "yk-log-level"
+	ArgLogEncoding            = "yk-log-encoding"
+	ArgLogFile                = "yk-log-file"
+	ArgEventChannelCapacity   = "yk-event-channel-capacity"
+	ArgDispatchTimeout        = "yk-dispatcher-timeout"
+	ArgKubeQPS                = "yk-kube-qps"
+	ArgKubeBurst              = "yk-kube-burst"
+	ArgOperatorPlugins        = "yk-operator-plugins"
+	ArgEnableConfigHotRefresh = "yk-enable-config-hot-refresh"
+	ArgDisableGangScheduling  = "yk-disable-gang-scheduling"
+	ArgUserLabelKey           = "yk-user-label-key"
+	ArgSchedulerName          = "yk-scheduler-name"
+)
+
+func getStringArg(flag *pflag.Flag, defaultValue string) string {
+	value := flag.Value.String()
+	if value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+func getTimeDurationArg(flag *pflag.Flag, defaultValue time.Duration) time.Duration {
+	if parsedValue, err := time.ParseDuration(flag.Value.String()); err == nil {
+		return parsedValue
+	}
+	return defaultValue
+}
+
+func getIntArg(flag *pflag.Flag, defaultValue int) int {
+	if parsedValue, err := strconv.Atoi(flag.Value.String()); err == nil {
+		return parsedValue
+	}
+	return defaultValue
+}
+
+func getBoolArg(flag *pflag.Flag, defaultValue bool) bool {
+	if parsedValue, err := strconv.ParseBool(flag.Value.String()); err == nil {
+		return parsedValue
+	}
+	return defaultValue
+}
+
+// SchedulerConfFactory implementation
+func NewSchedulerConf() *conf.SchedulerConf {
+	configuration := &conf.SchedulerConf{}
+
+	if pluginFlags == nil {
+		// too early to call logger here
+		panic("Plugin flags not initialized")
+	}
+
+	pluginFlags.VisitAll(func(flag *pflag.Flag) {
+		switch flag.Name {
+		case ArgSchedulerName:
+			configuration.SchedulerName = getStringArg(flag, DefaultSchedulerName)
+		case ArgClusterID:
+			configuration.ClusterID = getStringArg(flag, conf.DefaultClusterID)
+		case ArgClusterVersion:
+			configuration.ClusterVersion = getStringArg(flag, conf.DefaultClusterVersion)
+		case ArgPolicyGroup:
+			configuration.PolicyGroup = getStringArg(flag, conf.DefaultPolicyGroup)
+		case ArgSchedulingInterval:
+			configuration.Interval = getTimeDurationArg(flag, conf.DefaultSchedulingInterval)
+		case ArgKubeConfig:
+			configuration.KubeConfig = getStringArg(flag, "")
+		case ArgLogEncoding:
+			configuration.LogEncoding = getStringArg(flag, conf.DefaultLogEncoding)
+		case ArgLogLevel:
+			configuration.LoggingLevel = getIntArg(flag, conf.DefaultLoggingLevel)
+		case ArgLogFile:
+			configuration.LogFile = getStringArg(flag, "")
+		case ArgEventChannelCapacity:
+			configuration.EventChannelCapacity = getIntArg(flag, conf.DefaultEventChannelCapacity)
+		case ArgDispatchTimeout:
+			configuration.DispatchTimeout = getTimeDurationArg(flag, conf.DefaultDispatchTimeout)
+		case ArgKubeQPS:
+			configuration.KubeQPS = getIntArg(flag, conf.DefaultKubeQPS)
+		case ArgKubeBurst:
+			configuration.KubeBurst = getIntArg(flag, conf.DefaultKubeBurst)
+		case ArgEnableConfigHotRefresh:
+			configuration.EnableConfigHotRefresh = getBoolArg(flag, true)
+		case ArgDisableGangScheduling:
+			configuration.DisableGangScheduling = getBoolArg(flag, false)
+		case ArgUserLabelKey:
+			configuration.UserLabelKey = getStringArg(flag, constants.DefaultUserLabel)
+		case ArgOperatorPlugins:
+			configuration.OperatorPlugins = getStringArg(flag, "general,"+constants.AppManagerHandlerName)
+		}
+	})
+
+	return configuration
+}
+
+// handle to the initialized flags so that we can read them later
+var pluginFlags *pflag.FlagSet
+
+func InitCliFlagSet(command *cobra.Command) {
+	ykFlags := pflag.NewFlagSet("yunikorn", pflag.ExitOnError)
+	ykFlags.String(ArgSchedulerName, DefaultSchedulerName, "scheduler name to register YuniKorn under")
+	ykFlags.String(ArgClusterID, conf.DefaultClusterID, "cluster id")
+	ykFlags.String(ArgClusterVersion, conf.DefaultClusterVersion, "cluster version")
+	ykFlags.String(ArgPolicyGroup, conf.DefaultPolicyGroup, "policy group")
+	ykFlags.Duration(ArgSchedulingInterval, conf.DefaultSchedulingInterval, "scheduling interval in seconds")
+	ykFlags.String(ArgKubeConfig, "", "absolute path to the kubeconfig file")
+	ykFlags.Int(ArgLogLevel, conf.DefaultLoggingLevel, "logging level, available range [-1, 5], from DEBUG to FATAL.")
+	ykFlags.String(ArgLogEncoding, conf.DefaultLogEncoding, "log encoding, json or console")
+	ykFlags.String(ArgLogFile, "", "absolute log file path")
+	ykFlags.Int(ArgEventChannelCapacity, conf.DefaultEventChannelCapacity, "event channel capacity of dispatcher")
+	ykFlags.Duration(ArgDispatchTimeout, conf.DefaultDispatchTimeout, "timeout in seconds when dispatching an event")
+	ykFlags.Int(ArgKubeQPS, conf.DefaultKubeQPS, "the maximum QPS to kubernetes master from this client")
+	ykFlags.Int(ArgKubeBurst, conf.DefaultKubeBurst, "the maximum burst for throttle to kubernetes master from this client")
+	ykFlags.Bool(ArgEnableConfigHotRefresh, true, "enable auto-reload of scheduler configmap")
+	ykFlags.Bool(ArgDisableGangScheduling, false, "disable gang scheduling")
+	ykFlags.String(ArgUserLabelKey, constants.DefaultUserLabel, "provide pod label key to be used to identify an user")
+	ykFlags.String(ArgOperatorPlugins, "general,"+constants.AppManagerHandlerName,
+		"comma-separated list of operator plugin names, currently, only \"spark-k8s-operator\" and \""+
+			constants.AppManagerHandlerName+"\" is supported.")
+
+	ykNamedFlagSets := flag.NamedFlagSets{
+		Order: []string{"YuniKorn"},
+		FlagSets: map[string]*pflag.FlagSet{
+			"YuniKorn": ykFlags,
+		},
+	}
+
+	cols, _, err := term.TerminalSize(command.OutOrStdout())
+	if err != nil {
+		cols = 0
+	}
+
+	helpFunc := command.HelpFunc()
+	command.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		helpFunc(cmd, args)
+		flag.PrintSections(cmd.OutOrStdout(), ykNamedFlagSets, cols)
+	})
+
+	usageFunc := command.UsageFunc()
+	command.SetUsageFunc(func(cmd *cobra.Command) error {
+		err := usageFunc(cmd)
+		flag.PrintSections(cmd.OutOrStderr(), ykNamedFlagSets, cols)
+		return err
+	})
+
+	command.Flags().AddFlagSet(ykFlags)
+	pluginFlags = ykFlags
+}

--- a/pkg/schedulerplugin/conf/pluginconf_test.go
+++ b/pkg/schedulerplugin/conf/pluginconf_test.go
@@ -1,0 +1,52 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+package conf
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/assert"
+
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
+	defaults "github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
+)
+
+func TestDefaultValues(t *testing.T) {
+	cmd := &cobra.Command{}
+	InitCliFlagSet(cmd)
+	conf := NewSchedulerConf()
+
+	assert.Equal(t, conf.ClusterID, defaults.DefaultClusterID, "wrong cluster id")
+	assert.Equal(t, conf.ClusterVersion, defaults.DefaultClusterVersion, "wrong cluster version")
+	assert.Equal(t, conf.PolicyGroup, defaults.DefaultPolicyGroup, "wrong policy group")
+	assert.Equal(t, conf.Interval, defaults.DefaultSchedulingInterval, "wrong scheduling interval")
+	assert.Equal(t, conf.KubeConfig, "", "wrong kube config path")
+	assert.Equal(t, conf.LoggingLevel, defaults.DefaultLoggingLevel, "wrong logging level")
+	assert.Equal(t, conf.LogEncoding, defaults.DefaultLogEncoding, "wrong log encoding")
+	assert.Equal(t, conf.LogFile, "", "wrong log file")
+	assert.Equal(t, conf.EventChannelCapacity, defaults.DefaultEventChannelCapacity, "wrong event channel capacity")
+	assert.Equal(t, conf.DispatchTimeout, defaults.DefaultDispatchTimeout, "wrong dispatch timeout")
+	assert.Equal(t, conf.KubeQPS, defaults.DefaultKubeQPS, "wrong kube qps")
+	assert.Equal(t, conf.KubeBurst, defaults.DefaultKubeBurst, "wrong kube burst")
+	assert.Equal(t, conf.OperatorPlugins, "general,yunikorn-app", "wrong operator plugins")
+	assert.Equal(t, conf.EnableConfigHotRefresh, true, "config hot refresh not enabled")
+	assert.Equal(t, conf.DisableGangScheduling, false, "gang scheduling not enabled")
+	assert.Equal(t, conf.UserLabelKey, constants.DefaultUserLabel, "wrong user label")
+	assert.Equal(t, conf.SchedulerName, DefaultSchedulerName, "wrong scheduler name")
+}

--- a/pkg/schedulerplugin/scheduler_plugin.go
+++ b/pkg/schedulerplugin/scheduler_plugin.go
@@ -1,0 +1,191 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package schedulerplugin
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+
+	"github.com/apache/incubator-yunikorn-core/pkg/entrypoint"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/cache"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/dispatcher"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
+	pluginconf "github.com/apache/incubator-yunikorn-k8shim/pkg/schedulerplugin/conf"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/shim"
+	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/api"
+)
+
+const (
+	SchedulerPluginName = "YuniKornPlugin"
+)
+
+type YuniKornSchedulerPlugin struct {
+	sync.RWMutex
+	context *cache.Context
+}
+
+// ensure all required interfaces are implemented
+var _ framework.PreFilterPlugin = &YuniKornSchedulerPlugin{}
+var _ framework.FilterPlugin = &YuniKornSchedulerPlugin{}
+var _ framework.PostBindPlugin = &YuniKornSchedulerPlugin{}
+
+// Name returns the name of the plugin
+func (sp *YuniKornSchedulerPlugin) Name() string {
+	return SchedulerPluginName
+}
+
+// PreFilter is used to release pods to scheduler
+func (sp *YuniKornSchedulerPlugin) PreFilter(_ context.Context, _ *framework.CycleState, pod *v1.Pod) *framework.Status {
+	log.Logger().Debug("PreFilter check",
+		zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)))
+
+	// we don't process pods without appID defined
+	appID, err := utils.GetApplicationIDFromPod(pod)
+	if err != nil {
+		log.Logger().Info(fmt.Sprintf("Skipping pod %s/%s in the prefilter plugin because no applicationID is defined",
+			pod.Namespace, pod.Name))
+		return framework.NewStatus(framework.Success, "Deferring to default scheduler")
+	}
+
+	if app := sp.context.GetApplication(appID); app != nil {
+		if task, err := app.GetTask(string(pod.UID)); err == nil {
+			_, ok := sp.context.GetInProgressPodAllocation(string(pod.UID))
+			if ok {
+				// pod must have failed scheduling, reject it and return unschedulable
+				log.Logger().Info("Task failed scheduling, marking as rejected",
+					zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+					zap.String("taskID", task.GetTaskID()))
+				sp.context.RemovePendingPodAllocation(string(pod.UID))
+				dispatcher.Dispatch(cache.NewRejectTaskEvent(app.GetApplicationID(), task.GetTaskID(),
+					fmt.Sprintf("task %s rejected by scheduler", task.GetTaskID())))
+				return framework.NewStatus(framework.Unschedulable, "Pod is not ready for scheduling")
+			}
+
+			nodeID, ok := sp.context.GetPendingPodAllocation(string(pod.UID))
+			if !ok {
+				nodeID = "<none>"
+			}
+
+			if task.GetTaskState() == events.States().Task.Bound && ok {
+				log.Logger().Info("Releasing pod for scheduling (prefilter phase)",
+					zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+					zap.String("taskID", task.GetTaskID()),
+					zap.String("assignedNode", nodeID))
+
+				return framework.NewStatus(framework.Success, "")
+			}
+		}
+	}
+
+	return framework.NewStatus(framework.Unschedulable, "Pod is not ready for scheduling")
+}
+
+// PreFilterExtensions is unused
+func (sp *YuniKornSchedulerPlugin) PreFilterExtensions() framework.PreFilterExtensions {
+	return nil
+}
+
+// Filter is used to release specific pod/node combinations to scheduler
+func (sp *YuniKornSchedulerPlugin) Filter(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+	log.Logger().Debug("Filter check",
+		zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+		zap.String("node", nodeInfo.Node().Name))
+
+	// we don't process pods without appID defined
+	appID, err := utils.GetApplicationIDFromPod(pod)
+	if err != nil {
+		log.Logger().Info(fmt.Sprintf("Skipping pod %s/%s in the filter plugin because no applicationID is defined",
+			pod.Namespace, pod.Name))
+		return framework.NewStatus(framework.Success, "Deferring to default scheduler")
+	}
+
+	if app := sp.context.GetApplication(appID); app != nil {
+		if task, err := app.GetTask(string(pod.UID)); err == nil {
+			if task.GetTaskState() == events.States().Task.Bound {
+				if sp.context.StartPodAllocation(string(pod.UID), nodeInfo.Node().Name) {
+					log.Logger().Info("Releasing pod for scheduling (filter phase)",
+						zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+						zap.String("taskID", task.GetTaskID()),
+						zap.String("assignedNode", nodeInfo.Node().Name))
+					return framework.NewStatus(framework.Success, "")
+				}
+			}
+		}
+	}
+
+	return framework.NewStatus(framework.Unschedulable, "Pod is not fit for node")
+}
+
+// PostBind is used to mark allocations as completed once scheduling run is finished
+func (sp *YuniKornSchedulerPlugin) PostBind(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeName string) {
+	log.Logger().Debug("PostBind handler",
+		zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+		zap.String("assignedNode", nodeName))
+
+	// we don't process pods without appID defined
+	appID, err := utils.GetApplicationIDFromPod(pod)
+	if err != nil {
+		log.Logger().Info(fmt.Sprintf("Skipping pod %s/%s in the postbind plugin because no applicationID is defined",
+			pod.Namespace, pod.Name))
+		return
+	}
+
+	if app := sp.context.GetApplication(appID); app != nil {
+		if task, err := app.GetTask(string(pod.UID)); err == nil {
+			log.Logger().Info("Pod bound successfully",
+				zap.String("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)),
+				zap.String("taskID", task.GetTaskID()),
+				zap.String("assignedNode", nodeName))
+			sp.context.RemovePendingPodAllocation(string(pod.UID))
+		}
+	}
+}
+
+// NewSchedulerPlugin initializes a new plugin and returns it
+func NewSchedulerPlugin(_ runtime.Object, handle framework.Handle) (framework.Plugin, error) {
+	log.Logger().Info("Build info", zap.String("version", pluginconf.BuildVersion), zap.String("date", pluginconf.BuildDate))
+
+	// start the YK core scheduler
+	serviceContext := entrypoint.StartAllServices()
+	if sa, ok := serviceContext.RMProxy.(api.SchedulerAPI); ok {
+		// we need our own informer factory here because the informers we get from the framework handle aren't yet initialized
+		informerFactory := informers.NewSharedInformerFactory(handle.ClientSet(), 0)
+		ss := shim.NewShimSchedulerForPlugin(sa, informerFactory, conf.GetSchedulerConf())
+		ss.Run()
+
+		p := &YuniKornSchedulerPlugin{
+			context: ss.GetContext(),
+		}
+
+		events.SetRecorder(handle.EventRecorder())
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("internal error: serviceContext should implement interface api.SchedulerAPI")
+}

--- a/pkg/shim/scheduler_events.go
+++ b/pkg/shim/scheduler_events.go
@@ -16,7 +16,7 @@
  limitations under the License.
 */
 
-package main
+package shim
 
 import "github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -16,7 +16,7 @@
  limitations under the License.
 */
 
-package main
+package shim
 
 import (
 	"fmt"
@@ -82,7 +82,7 @@ func (fc *MockScheduler) init(queues string) {
 }
 
 func (fc *MockScheduler) start() {
-	fc.scheduler.run()
+	fc.scheduler.Run()
 }
 
 func (fc *MockScheduler) addNode(nodeName string, memory, cpu int64) error {
@@ -215,5 +215,5 @@ func (fc *MockScheduler) waitAndVerifySchedulerAllocations(
 
 func (fc *MockScheduler) stop() {
 	close(fc.stopChan)
-	fc.scheduler.stop()
+	fc.scheduler.Stop()
 }

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -16,7 +16,7 @@
  limitations under the License.
 */
 
-package main
+package shim
 
 import (
 	"fmt"
@@ -162,8 +162,8 @@ func TestSchedulerRegistrationFailed(t *testing.T) {
 	ctx := cache.NewContext(mockedAPIProvider)
 	shim := newShimSchedulerInternal(ctx, mockedAPIProvider,
 		appmgmt.NewAMService(mockedAMProtocol, mockedAPIProvider), callback)
-	shim.run()
-	defer shim.stop()
+	shim.Run()
+	defer shim.Stop()
 
 	err := waitShimSchedulerState(shim, events.States().Scheduler.Stopped, 5*time.Second)
 	assert.NilError(t, err)

--- a/scripts/plugin-conf-gen.sh
+++ b/scripts/plugin-conf-gen.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+#limitations under the License.
+#
+
+KCFG=$1
+BIN=$2
+cat > ${BIN}/scheduler-config.yaml <<EOL
+apiVersion: kubescheduler.config.k8s.io/v1beta1
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+clientConnection:
+  kubeconfig: ${KCFG}
+profiles:
+  - schedulerName: yunikorn
+    plugins:
+      preFilter:
+        enabled:
+        - name: YuniKornPlugin
+      filter:
+        enabled:
+        - name: YuniKornPlugin
+      postBind:
+        enabled:
+        - name: YuniKornPlugin
+EOL


### PR DESCRIPTION
### What is this PR for?
This PR implements a new build mode for YuniKorn which allows it to run as a set of plugins on top of the default Kubernetes scheduler. This should allow for closer behavior to the default scheduler as well as the ability to bypass YuniKorn-specific functionality for pods which are not annotated with an `applicationId` label.

This PR makes no functional changes to the default YuniKorn build, but adds new Makefile targets to support build / running YuniKorn as a scheduler plugin:

- `build_plugin` Build the plugin code.
- `run_plugin` Run the plugin code locally.
- `plugin_image` Create a Docker image from the plugin code. this should mostly be a drop-in replacement for the default YuniKorn image.

This feature should be considered `experimental` at this stage. Hopefully we can provide it as a tech-preview for 1.0.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [x] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-971

### How should this be tested?
Some unit tests added for configuration, remainder is covered via e2e tests (all passing).

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
