### PR TITLE
[YUNIKORN-995] Use v1 for ClusterRoleBinding rbac.authorization.k8s.io instead of v1beta1

### DIFF
--- a/deployments/admission-controllers/scheduler/admission_util.sh
+++ b/deployments/admission-controllers/scheduler/admission_util.sh
@@ -113,7 +113,7 @@ precheck() {
 create_resources() {
   KEY_DIR=$1
   # Generate keys into a temporary directory.
-  if ! ${basedir}/generate-signed-ca.sh "${KEY_DIR}"
+  if ! /bin/sh ${basedir}/generate-signed-ca.sh "${KEY_DIR}"
   then
     echo "failed to generate signed ca!"
     exit 1

--- a/deployments/admission-controllers/scheduler/generate-signed-ca.sh
+++ b/deployments/admission-controllers/scheduler/generate-signed-ca.sh
@@ -65,7 +65,7 @@ kubectl delete csr ${csrName} 2>/dev/null || true
 
 # send to K8s
 cat <<EOF | kubectl create -f -
-apiVersion: certificates.k8s.io/v1beta1
+apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
   name: ${csrName}
@@ -73,6 +73,7 @@ spec:
   groups:
   - system:authenticated
   request: $(cat ${tmpdir}/server.csr | base64 | tr -d '\n')
+  signerName: kubernetes.io/kube-apiserver-client
   usages:
   - digital signature
   - key encipherment

--- a/deployments/admission-controllers/scheduler/templates/mutations.yaml.template
+++ b/deployments/admission-controllers/scheduler/templates/mutations.yaml.template
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: yunikorn-admission-controller-mutations
@@ -18,3 +18,5 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["pods"]
     failurePolicy: Ignore
+    admissionReviewVersions: ["v1"]
+    sideEffects: None

--- a/deployments/admission-controllers/scheduler/templates/validations.yaml.template
+++ b/deployments/admission-controllers/scheduler/templates/validations.yaml.template
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: yunikorn-admission-controller-validations
@@ -18,3 +18,5 @@ webhooks:
         apiVersions: ["v1"]
         resources: ["configmaps"]
     failurePolicy: Ignore
+    admissionReviewVersions: ["v1"]
+    sideEffects: None

--- a/deployments/scheduler/yunikorn-rbac.yaml
+++ b/deployments/scheduler/yunikorn-rbac.yaml
@@ -20,7 +20,7 @@ metadata:
   name: yunikorn-admin
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: yunikorn-rbac


### PR DESCRIPTION
### What is this PR for?
Helm installation for Yunikorn using Kubernetes version 1.22 currently fails, see details [here](https://issues.apache.org/jira/browse/YUNIKORN-995) and tickets referenced in the comments. This PR was originally intended to upgrade the `apiVersion` of `ClusterRoleBinding` from `v1beta -> v1`, but fixing that issue alone did not enable a successful helm installation of Yunikorn using K8s 1.22. As a result, this PR has come to encompass other changes required to do so.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Rebase on `master` once https://github.com/apache/incubator-yunikorn-k8shim/pull/346 is merged to resume testing
* [ ] - Verify changes don't break ability to helm install Yunikorn with K8s 1.19+

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-995

### How should this be tested?
`make image` locally and use the existing `0.12.1` helm chart to ensure scheduler/admission controller can be brought up successfully with all K8s versions 1.19+. Also ensure existing unit + e2e tests pass for all versions.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
