### PR TITLE
[YUNIKORN-937] Update eventrecorder usage to new K8S API

### DIFF
--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -422,7 +422,7 @@ func (app *Application) scheduleTasks(taskScheduleCondition func(t *Task) bool) 
 					log.Logger().Warn("init task failed", zap.Error(err))
 				}
 			} else {
-				events.GetRecorder().Event(task.GetTaskPod(), v1.EventTypeWarning, "FailedScheduling", err.Error())
+				events.GetRecorder().Eventf(task.GetTaskPod(), nil, v1.EventTypeWarning, "FailedScheduling", "FailedScheduling", err.Error())
 				log.Logger().Debug("task is not ready for scheduling",
 					zap.String("appID", task.applicationID),
 					zap.String("taskID", task.taskID),
@@ -633,7 +633,7 @@ func (app *Application) handleFailApplicationEvent(event *fsm.Event) {
 			errMsgArr := strings.Split(errMsg, ":")
 			failTaskPodWithReasonAndMsg(task, constants.ApplicationRejectedFailure, errMsgArr[1])
 		}
-		events.GetRecorder().Eventf(task.GetTaskPod(), v1.EventTypeWarning, "ApplicationFailed",
+		events.GetRecorder().Eventf(task.GetTaskPod(), nil, v1.EventTypeWarning, "ApplicationFailed", "ApplicationFailed",
 			"Application %s scheduling failed, reason: %s", app.applicationID, errMsg)
 	}
 }

--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -31,7 +31,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	k8sEvents "k8s.io/client-go/tools/events"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/apis/yunikorn.apache.org/v1alpha1"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
@@ -206,7 +206,7 @@ func TestFailApplication(t *testing.T) {
 	assertAppState(t, app2, events.States().Application.Failed, 3*time.Second)
 	assert.Equal(t, rt.time, int64(0))
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(record.NewFakeRecorder(1024))
+	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
@@ -315,7 +315,7 @@ func TestSetUnallocatedPodsToFailedWhenFailApplication(t *testing.T) {
 	assert.Equal(t, newPod3.Status.Phase, v1.PodFailed, 3*time.Second)
 	assert.Equal(t, newPod3.Status.Reason, constants.ApplicationInsufficientResourcesFailure, 3*time.Second)
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(record.NewFakeRecorder(1024))
+	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
@@ -416,7 +416,7 @@ func TestSetUnallocatedPodsToFailedWhenRejectApplication(t *testing.T) {
 	assert.Equal(t, newPod2.Status.Phase, v1.PodFailed, 3*time.Second)
 	assert.Equal(t, newPod2.Status.Reason, constants.ApplicationRejectedFailure, 3*time.Second)
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(record.NewFakeRecorder(1024))
+	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestReleaseAppAllocation(t *testing.T) {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -134,7 +134,7 @@ func (ctx *Context) addNode(obj interface{}) {
 	ctx.nodes.addNode(node)
 
 	// post the event
-	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "NodeAccepted",
+	events.GetRecorder().Eventf(node, nil, v1.EventTypeNormal, "NodeAccepted", "NodeAccepted",
 		fmt.Sprintf("node %s is accepted by the scheduler", node.Name))
 }
 
@@ -194,7 +194,7 @@ func (ctx *Context) deleteNode(obj interface{}) {
 	ctx.nodes.deleteNode(node)
 
 	// post the event
-	events.GetRecorder().Eventf(node, v1.EventTypeNormal, "NodeDeleted",
+	events.GetRecorder().Eventf(node, nil, v1.EventTypeNormal, "NodeDeleted", "NodeDeleted",
 		fmt.Sprintf("node %s is deleted from the scheduler", node.Name))
 }
 
@@ -667,8 +667,8 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 				taskID := record.ObjectID
 				appID := record.GroupID
 				if task, err := ctx.getTask(appID, taskID); err == nil {
-					events.GetRecorder().Event(task.GetTaskPod(),
-						v1.EventTypeNormal, record.Reason, record.Message)
+					events.GetRecorder().Eventf(task.GetTaskPod(), nil,
+						v1.EventTypeNormal, record.Reason, record.Reason, record.Message)
 				} else {
 					log.Logger().Warn("task event is not published because task is not found",
 						zap.String("appID", appID),
@@ -691,8 +691,8 @@ func (ctx *Context) PublishEvents(eventRecords []*si.EventRecord) {
 						zap.String("event", record.String()))
 					continue
 				}
-				events.GetRecorder().Event(node,
-					v1.EventTypeNormal, record.Reason, record.Message)
+				events.GetRecorder().Eventf(node, nil,
+					v1.EventTypeNormal, record.Reason, record.Reason, record.Message)
 			default:
 				log.Logger().Warn("Unsupported event type, currently only supports to publish request event records",
 					zap.String("type", record.Type.String()))
@@ -747,8 +747,8 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 					Reason:  "SchedulingSkipped",
 					Message: request.Reason,
 				}) {
-				events.GetRecorder().Eventf(task.pod,
-					v1.EventTypeNormal, "PodUnschedulable",
+				events.GetRecorder().Eventf(task.pod, nil,
+					v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
 					"Task %s is skipped from scheduling because the queue quota has been exceed", task.alias)
 			}
 		case si.UpdateContainerSchedulingStateRequest_FAILED:
@@ -760,8 +760,8 @@ func (ctx *Context) HandleContainerStateUpdate(request *si.UpdateContainerSchedu
 					Reason:  v1.PodReasonUnschedulable,
 					Message: request.Reason,
 				}) {
-				events.GetRecorder().Eventf(task.pod,
-					v1.EventTypeNormal, "PodUnschedulable",
+				events.GetRecorder().Eventf(task.pod, nil,
+					v1.EventTypeNormal, "PodUnschedulable", "PodUnschedulable",
 					"Task %s is pending for the requested resources become available", task.alias)
 			}
 		default:

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -30,7 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/record"
+	k8sEvents "k8s.io/client-go/tools/events"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/appmgmt/interfaces"
@@ -568,7 +568,7 @@ func TestRemoveTask(t *testing.T) {
 
 func TestNodeEventFailsPublishingWithoutNode(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
-	recorder, ok := events.GetRecorder().(*record.FakeRecorder)
+	recorder, ok := events.GetRecorder().(*k8sEvents.FakeRecorder)
 	if !ok {
 		t.Fatal("the EventRecorder is expected to be of type FakeRecorder")
 	}
@@ -599,7 +599,7 @@ func TestNodeEventFailsPublishingWithoutNode(t *testing.T) {
 
 func TestNodeEventPublishedCorrectly(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
-	recorder, ok := events.GetRecorder().(*record.FakeRecorder)
+	recorder, ok := events.GetRecorder().(*k8sEvents.FakeRecorder)
 	if !ok {
 		t.Fatal("the EventRecorder is expected to be of type FakeRecorder")
 	}
@@ -644,7 +644,7 @@ func TestNodeEventPublishedCorrectly(t *testing.T) {
 
 func TestPublishEventsWithNotExistingAsk(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
-	recorder, ok := events.GetRecorder().(*record.FakeRecorder)
+	recorder, ok := events.GetRecorder().(*k8sEvents.FakeRecorder)
 	if !ok {
 		t.Fatal("the EventRecorder is expected to be of type FakeRecorder")
 	}
@@ -687,7 +687,7 @@ func TestPublishEventsWithNotExistingAsk(t *testing.T) {
 
 func TestPublishEventsCorrectly(t *testing.T) {
 	conf.GetSchedulerConf().SetTestMode(true)
-	recorder, ok := events.GetRecorder().(*record.FakeRecorder)
+	recorder, ok := events.GetRecorder().(*k8sEvents.FakeRecorder)
 	if !ok {
 		t.Fatal("the EventRecorder is expected to be of type FakeRecorder")
 	}

--- a/pkg/cache/task_test.go
+++ b/pkg/cache/task_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apis "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/record"
+	k8sEvents "k8s.io/client-go/tools/events"
 
 	"github.com/apache/incubator-yunikorn-core/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
@@ -521,7 +521,7 @@ func TestHandleSubmitTaskEvent(t *testing.T) {
 	assert.Equal(t, rt.time, int64(2))
 
 	// Test over, set Recorder back fake type
-	events.SetRecorderForTest(record.NewFakeRecorder(1024))
+	events.SetRecorderForTest(k8sEvents.NewFakeRecorder(1024))
 }
 
 func TestSimultaneousTaskCompleteAndAllocate(t *testing.T) {

--- a/pkg/common/events/recorder_mock.go
+++ b/pkg/common/events/recorder_mock.go
@@ -37,7 +37,7 @@ func (mr *MockedRecorder) Event(object runtime.Object, eventtype, reason, messag
 
 }
 
-func (mr *MockedRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+func (mr *MockedRecorder) Eventf(regarding runtime.Object, related runtime.Object, eventtype, reason, action, note string, args ...interface{}) {
 	mr.OnEventf()
 }
 

--- a/pkg/common/events/recorder_test.go
+++ b/pkg/common/events/recorder_test.go
@@ -33,5 +33,5 @@ func TestInit(t *testing.T) {
 	// skips initiating a real event recorder
 	conf.GetSchedulerConf().SetTestMode(true)
 	recorder := GetRecorder()
-	assert.Equal(t, reflect.TypeOf(recorder).String(), "*record.FakeRecorder")
+	assert.Equal(t, reflect.TypeOf(recorder).String(), "*events.FakeRecorder")
 }

--- a/pkg/plugin/predicates/predicate_manager.go
+++ b/pkg/plugin/predicates/predicate_manager.go
@@ -77,8 +77,8 @@ func (p *predicateManagerImpl) predicatesAllocate(pod *v1.Pod, node *framework.N
 	state := framework.NewCycleState()
 	plugin, err := p.podFitsNode(ctx, state, *p.allocationPreFilters, *p.allocationFilters, pod, node)
 	if err != nil {
-		events.GetRecorder().Eventf(pod, v1.EventTypeWarning,
-			"FailedScheduling", "predicate is not satisfied, error: %s", err.Error())
+		events.GetRecorder().Eventf(pod, nil, v1.EventTypeWarning,
+			"FailedScheduling", "FailedScheduling", "predicate is not satisfied, error: %s", err.Error())
 	}
 	return plugin, err
 }


### PR DESCRIPTION
### What is this PR for?
Upgrade usage of EventRecorder to report "k8s.io/api/events/v1beta1".Event events instead of "k8s.io/api/core/v1".Event events. More details on deprecation of core API can be found under Rule 1's Note [here](https://kubernetes.io/docs/reference/using-api/deprecation-policy/).


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-937

### How should this be tested?
Existing unit + e2e tests should pass.

### Screenshots (if appropriate)

### Questions:
