### PR TITLE
[YUNIKORN-1038] failure to ignore scheduler pod

### DIFF
--- a/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
+++ b/pkg/plugin/admissioncontrollers/webhook/admission_controller.go
@@ -115,6 +115,7 @@ func admissionResponseBuilder(uid string, allowed bool, resultMessage string, pa
 	}
 	return res
 }
+
 func (c *admissionController) mutate(req *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	if req == nil {
 		log.Logger().Warn("empty request received")
@@ -149,7 +150,7 @@ func (c *admissionController) mutate(req *admissionv1.AdmissionRequest) *admissi
 	if labelAppValue, ok := pod.Labels[constants.LabelApp]; ok {
 		if labelAppValue == yunikornPod {
 			log.Logger().Info("ignore yunikorn pod")
-			admissionResponseBuilder(uid, true, "", nil)
+			return admissionResponseBuilder(uid, true, "", nil)
 		}
 	}
 


### PR DESCRIPTION
### What is this PR for?
A missing return causes the admission controller to not ignore the
yunikorn pods. This could cause changes on the yunikorn pod which should
not be made.

### What type of PR is it?
* Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1038

### How should this be tested?
Restart of the scheduler pod with the admission controller running.
Needs manual confirmation
