### PR TITLE
[YUNIKORN-949] Location of the state dump file should be configurable

### DIFF
--- a/deployments/scheduler/scheduler.yaml
+++ b/deployments/scheduler/scheduler.yaml
@@ -47,6 +47,11 @@ spec:
               value: myCluster
             - name: CLUSTER_VERSION
               value: latest
+            - name: STATE_DUMP_FILE_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: yunikorn-configs
+                  key: stateDumpFilePath
           resources:
             requests:
               cpu: 200m

--- a/deployments/scheduler/yunikorn-configs.yaml
+++ b/deployments/scheduler/yunikorn-configs.yaml
@@ -30,3 +30,4 @@ data:
         queues:
           - name: root
             submitacl: '*'
+  stateDumpFilePath: "yunikorn-state.txt"


### PR DESCRIPTION
### What is this PR for?
Shim changes for enabling the state dump file should be configurable instead of hardcoded.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-949

### How should this be tested?
* Manually using non-helm deployment.

### Screenshots (if appropriate)

### Questions:
