### PR TITLE
[YUNIKORN-1060] Remove Kubernetes 1.19 from e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s: [v1.23.1, v1.22.4, v1.21.2, v1.20.7, v1.19.11]
+        k8s: [v1.23.1, v1.22.4, v1.21.2, v1.20.7]
         plugin: ['', '--plugin']
     steps:
       - uses: actions/setup-go@v2

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -225,7 +225,6 @@ Usage: $(basename "$0") -a <action> -n <kind-cluster-name> -v <kind-node-image-v
   --plugin                     use scheduler-plugin-latest image instead of scheduler-latest
 
 Examples:
-  $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.19.11"
   $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.20.7"
   $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.21.2"
   $(basename "$0") -a test -n "yk8s" -v "kindest/node:v1.22.4"


### PR DESCRIPTION
### What is this PR for?
Remove EOL version of K8S from our e2e test matrix.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1060

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
