### PR TITLE
[YUNIKORN-1052] Add more cluster-wide metrics to Yunikorn

### DIFF
--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"strconv"
 	"sync"
 
 	"github.com/looplab/fsm"
@@ -42,6 +43,7 @@ type SchedulerNode struct {
 	capacity            *si.Resource
 	occupied            *si.Resource
 	schedulable         bool
+	ready               bool
 	existingAllocations []*si.Allocation
 	schedulerAPI        api.SchedulerAPI
 	fsm                 *fsm.FSM
@@ -49,7 +51,7 @@ type SchedulerNode struct {
 }
 
 func newSchedulerNode(nodeName string, nodeUID string, nodeLabels string,
-	nodeResource *si.Resource, schedulerAPI api.SchedulerAPI, schedulable bool) *SchedulerNode {
+	nodeResource *si.Resource, schedulerAPI api.SchedulerAPI, schedulable bool, ready bool) *SchedulerNode {
 	schedulerNode := &SchedulerNode{
 		name:         nodeName,
 		uid:          nodeUID,
@@ -59,6 +61,7 @@ func newSchedulerNode(nodeName string, nodeUID string, nodeLabels string,
 		schedulerAPI: schedulerAPI,
 		schedulable:  schedulable,
 		lock:         &sync.RWMutex{},
+		ready:        ready,
 	}
 	schedulerNode.initFSM()
 	return schedulerNode
@@ -162,6 +165,7 @@ func (n *SchedulerNode) handleNodeRecovery(event *fsm.Event) {
 					constants.DefaultNodeAttributeHostNameKey:   n.name,
 					constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
 					constants.DefaultNodeAttributeNodeLabelsKey: n.labels,
+					"ready": strconv.FormatBool(n.ready),
 				},
 				ExistingAllocations: n.existingAllocations,
 				Action:              si.NodeInfo_CREATE,

--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -165,7 +165,7 @@ func (n *SchedulerNode) handleNodeRecovery(event *fsm.Event) {
 					constants.DefaultNodeAttributeHostNameKey:   n.name,
 					constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
 					constants.DefaultNodeAttributeNodeLabelsKey: n.labels,
-					"ready": strconv.FormatBool(n.ready),
+					constants.NodeReadyAttribute:                strconv.FormatBool(n.ready),
 				},
 				ExistingAllocations: n.existingAllocations,
 				Action:              si.NodeInfo_CREATE,

--- a/pkg/cache/node_test.go
+++ b/pkg/cache/node_test.go
@@ -67,6 +67,6 @@ func NewTestSchedulerNode() *SchedulerNode {
 		AddResource(constants.Memory, 1).
 		AddResource(constants.CPU, 1).
 		Build()
-	node := newSchedulerNode("host001", "UID001", "{\"label1\":\"key1\",\"label2\":\"key2\"}", r1, api, false)
+	node := newSchedulerNode("host001", "UID001", "{\"label1\":\"key1\",\"label2\":\"key2\"}", r1, api, false, true)
 	return node
 }

--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -23,6 +23,7 @@ const DefaultNodeAttributeHostNameKey = "si.io/hostname"
 const DefaultNodeAttributeRackNameKey = "si.io/rackname"
 const DefaultNodeAttributeNodeLabelsKey = "si.io/nodelabels"
 const DefaultRackName = "/rack-default"
+const NodeReadyAttribute = "ready"
 
 // Application
 const LabelApp = "app"

--- a/pkg/common/node.go
+++ b/pkg/common/node.go
@@ -28,12 +28,13 @@ import (
 type Node struct {
 	name     string
 	uid      string
+	ready    bool
 	capacity *si.Resource
 	occupied *si.Resource
 }
 
 func NewNode(name, uid string, capacity *si.Resource, occupied *si.Resource) Node {
-	return Node{name, uid, capacity, occupied}
+	return Node{name, uid, true, capacity, occupied}
 }
 
 func CreateFrom(node *v1.Node) Node {
@@ -41,6 +42,7 @@ func CreateFrom(node *v1.Node) Node {
 		name:     node.Name,
 		uid:      string(node.UID),
 		capacity: GetNodeResource(&node.Status),
+		ready:    HasReadyCondition(node),
 	}
 }
 
@@ -50,4 +52,13 @@ func CreateFromNodeSpec(nodeName string, nodeUID string, nodeResource *si.Resour
 		uid:      nodeUID,
 		capacity: nodeResource,
 	}
+}
+
+func HasReadyCondition(node *v1.Node) bool {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == v1.NodeReady && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	v1 "k8s.io/api/core/v1"
+	"strconv"
 
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
@@ -159,7 +160,9 @@ func CreateUpdateRequestForUpdatedNode(node Node) si.NodeRequest {
 	// Currently only includes resource in the update request
 	nodeInfo := &si.NodeInfo{
 		NodeID:              node.name,
-		Attributes:          make(map[string]string),
+		Attributes:          map[string]string {
+			"ready":		 strconv.FormatBool(node.ready),
+		},
 		SchedulableResource: node.capacity,
 		OccupiedResource:    node.occupied,
 		Action:              si.NodeInfo_UPDATE,

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -159,9 +159,9 @@ func CreateUpdateRequestForNewNode(node Node) si.NodeRequest {
 func CreateUpdateRequestForUpdatedNode(node Node) si.NodeRequest {
 	// Currently only includes resource in the update request
 	nodeInfo := &si.NodeInfo{
-		NodeID:              node.name,
-		Attributes:          map[string]string {
-			"ready":		 strconv.FormatBool(node.ready),
+		NodeID: node.name,
+		Attributes: map[string]string{
+			constants.NodeReadyAttribute: strconv.FormatBool(node.ready),
 		},
 		SchedulableResource: node.capacity,
 		OccupiedResource:    node.occupied,


### PR DESCRIPTION
### What is this PR for?
Add more cluster-wide metrics to Yunikorn.
We're exposing the "Ready" condition from the shim side on node addition/update. 
https://kubernetes.io/docs/concepts/architecture/nodes/#condition

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1052

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
