### PR TITLE
[YUNIKORN-1076] Emit K8s event for invalid Task Group annotation

### DIFF
--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -32,11 +32,11 @@ import (
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/client"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/constants"
+	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/events"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/common/utils"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/conf"
 	"github.com/apache/incubator-yunikorn-k8shim/pkg/log"
 	"github.com/apache/incubator-yunikorn-scheduler-interface/lib/go/si"
-
 	"go.uber.org/zap"
 )
 
@@ -146,6 +146,8 @@ func (os *Manager) getAppMetadata(pod *v1.Pod) (interfaces.ApplicationMetadata, 
 				zap.String("namespace", pod.Namespace),
 				zap.String("name", pod.Name),
 				zap.Error(err))
+			events.GetRecorder().Eventf(pod, nil, v1.EventTypeWarning, "TaskGroupFormatError", "TaskGroupFormatError",
+				"unable to get taskGroups for pod, pod namespace: %s, pod name: %s, reason: %s", appID, pod.Namespace, pod.Name, err.Error())
 		}
 	}
 

--- a/pkg/appmgmt/general/general.go
+++ b/pkg/appmgmt/general/general.go
@@ -146,8 +146,8 @@ func (os *Manager) getAppMetadata(pod *v1.Pod) (interfaces.ApplicationMetadata, 
 				zap.String("namespace", pod.Namespace),
 				zap.String("name", pod.Name),
 				zap.Error(err))
-			events.GetRecorder().Eventf(pod, nil, v1.EventTypeWarning, "TaskGroupFormatError", "TaskGroupFormatError",
-				"unable to get taskGroups for pod, pod namespace: %s, pod name: %s, reason: %s", appID, pod.Namespace, pod.Name, err.Error())
+			events.GetRecorder().Eventf(pod, nil, v1.EventTypeWarning, "TaskGroupsError", "TaskGroupsError",
+				"unable to get taskGroups for pod, reason: %s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
### What is this PR for?
add pod event  for `GetTaskGroupsFromAnnotation` error

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1076

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
