### PR TITLE
[YUNIKORN-1100] Fix scheduler cache inconsistencies

### DIFF
--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -475,8 +475,7 @@ func (ctx *Context) ForgetPod(name string) {
 		ctx.schedulerCache.ForgetPod(pod)
 		return
 	}
-	log.Logger().Debug("unable to forget pod",
-		zap.String("reason", fmt.Sprintf("pod %s not found in scheduler cache", name)))
+	log.Logger().Debug("unable to forget pod: not found in cache", zap.String("pod", name))
 }
 
 func (ctx *Context) UpdateApplication(app *Application) {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -165,7 +165,7 @@ func (ctx *Context) updateNode(oldObj, newObj interface{}) {
 	}
 
 	// update secondary cache
-	ctx.schedulerCache.UpdateNode(oldNode, newNode)
+	ctx.schedulerCache.UpdateNode(newNode)
 
 	// update primary cache
 	ctx.nodes.updateNode(oldNode, newNode)
@@ -240,7 +240,7 @@ func (ctx *Context) removePodFromCache(obj interface{}) {
 }
 
 func (ctx *Context) updatePodInCache(oldObj, newObj interface{}) {
-	oldPod, err := utils.Convert2Pod(oldObj)
+	_, err := utils.Convert2Pod(oldObj)
 	if err != nil {
 		log.Logger().Error("failed to update pod in cache", zap.Error(err))
 		return
@@ -258,7 +258,7 @@ func (ctx *Context) updatePodInCache(oldObj, newObj interface{}) {
 		return
 	}
 
-	ctx.schedulerCache.UpdatePod(oldPod, newPod)
+	ctx.schedulerCache.UpdatePod(newPod)
 }
 
 // filter pods by scheduler name and state

--- a/pkg/cache/context_recovery.go
+++ b/pkg/cache/context_recovery.go
@@ -123,10 +123,7 @@ func (ctx *Context) recover(mgr []interfaces.Recoverable, due time.Duration) err
 				}
 				occupiedResource = common.Add(occupiedResource, common.GetPodResource(&pod))
 				nodeOccupiedResources[pod.Spec.NodeName] = occupiedResource
-				if err = ctx.nodes.cache.AddPod(&pod); err != nil {
-					log.Logger().Warn("failed to update scheduler-cache",
-						zap.Error(err))
-				}
+				ctx.nodes.cache.AddPod(&pod)
 			}
 		}
 

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -358,12 +358,10 @@ func TestUpdatePodInCache(t *testing.T) {
 	context.updatePodInCache(nil, pod1)
 	context.updatePodInCache(pod1, nil)
 
-	// ensure a terminated pod doesn't result in an update
+	// ensure a terminated pod is removed
 	context.updatePodInCache(pod1, pod3)
 	found, ok := context.schedulerCache.GetPod("UID-00001")
-	if assert.Check(t, ok, "pod not found after update") {
-		assert.Check(t, found.GetAnnotations()["test.state"] == "new", "pod state updated when new pod is terminated")
-	}
+	assert.Check(t, !ok, "pod still found after termination")
 
 	// ensure a non-terminated pod is updated
 	context.updatePodInCache(pod1, pod2)

--- a/pkg/cache/external/scheduler_cache.go
+++ b/pkg/cache/external/scheduler_cache.go
@@ -103,7 +103,7 @@ func (cache *SchedulerCache) AddNode(node *v1.Node) {
 	cache.updateNode(node)
 }
 
-func (cache *SchedulerCache) UpdateNode(_, newNode *v1.Node) {
+func (cache *SchedulerCache) UpdateNode(newNode *v1.Node) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	cache.dumpState("UpdateNode.Pre")
@@ -235,7 +235,7 @@ func (cache *SchedulerCache) AddPod(pod *v1.Pod) {
 }
 
 // UpdatePod updates a pod in the cache
-func (cache *SchedulerCache) UpdatePod(_, newPod *v1.Pod) {
+func (cache *SchedulerCache) UpdatePod(newPod *v1.Pod) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	cache.dumpState("UpdatePod.Pre")

--- a/pkg/cache/node_coordinator.go
+++ b/pkg/cache/node_coordinator.go
@@ -85,10 +85,7 @@ func (c *nodeResourceCoordinator) updatePod(old, new interface{}) {
 		// we need to notify scheduler-core to re-sync the node resource
 		podResource := common.GetPodResource(newPod)
 		c.nodes.updateNodeOccupiedResources(newPod.Spec.NodeName, podResource, AddOccupiedResource)
-		if err := c.nodes.cache.AddPod(newPod); err != nil {
-			log.Logger().Warn("failed to update scheduler-cache",
-				zap.Error(err))
-		}
+		c.nodes.cache.AddPod(newPod)
 		return
 	}
 

--- a/pkg/callback/scheduler_callback.go
+++ b/pkg/callback/scheduler_callback.go
@@ -78,9 +78,7 @@ func (callback *AsyncRMCallback) UpdateAllocation(response *si.AllocationRespons
 			zap.String("UUID", release.UUID))
 
 		// update cache
-		if err := callback.context.ForgetPod(release.GetAllocationKey()); err != nil {
-			return err
-		}
+		callback.context.ForgetPod(release.GetAllocationKey())
 
 		// TerminationType 0 mean STOPPED_BY_RM
 		if release.TerminationType != si.TerminationType_STOPPED_BY_RM {


### PR DESCRIPTION
### What is this PR for?
Fix leaks and inconsistencies in the shim scheduler cache.

Many of these issues have been shown to lead to scheduling failures (such as hitting max Pod limits) because we don't properly cleanup allocations.

- Made Add/Update/Remove Pod/Node handlers idempotent and removed error returns wherever possible
- Ensure RemoveNode properly removes any associated Pod allocations
- Added debugging hooks to pre/post handlers to dump state of scheduler cache
- Handle terminated pods in a similar fashion to removed Pods
- Fix leaking of assumed pods
- Fix duplicate addition of pods to NodeInfo.Pods structure
- Track pod -> node assignments separately from NodeInfo as NodeInfo stores pods in a list and doesn't check for duplicates
- Refactored Add/Update methods to share logic wherever possible
- Log both podKey and podName when updates are made

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1100

### How should this be tested?
Unit tests updated and debug logs show that we are no longer leaking objects.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
