### PR TITLE
[YUNIKORN-1101] idempotent remove application and remove task in context

### DIFF
--- a/pkg/appmgmt/interfaces/amprotocol.go
+++ b/pkg/appmgmt/interfaces/amprotocol.go
@@ -48,7 +48,7 @@ type ApplicationManagementProtocol interface {
 	// remove task from the app
 	// return an error if for some reason the task cannot be removed
 	// e.g app that owns this task is not found in context.
-	RemoveTask(appID, taskID string) error
+	RemoveTask(appID, taskID string)
 
 	// notify the context that an app is completed,
 	// this will trigger some consequent operations for the given app

--- a/pkg/cache/amprotocol_mock.go
+++ b/pkg/cache/amprotocol_mock.go
@@ -82,11 +82,9 @@ func (m *MockedAMProtocol) AddTask(request *interfaces.AddTaskRequest) interface
 	}
 }
 
-func (m *MockedAMProtocol) RemoveTask(appID, taskID string) error {
+func (m *MockedAMProtocol) RemoveTask(appID, taskID string) {
 	if app, ok := m.applications[appID]; ok {
-		return app.removeTask(taskID)
-	} else {
-		return fmt.Errorf("app not found")
+		app.removeTask(taskID)
 	}
 }
 

--- a/pkg/cache/application.go
+++ b/pkg/cache/application.go
@@ -275,18 +275,17 @@ func (app *Application) addTask(task *Task) {
 	app.taskMap[task.taskID] = task
 }
 
-func (app *Application) removeTask(taskID string) error {
+func (app *Application) removeTask(taskID string) {
 	app.lock.Lock()
 	defer app.lock.Unlock()
-	if _, ok := app.taskMap[taskID]; ok {
-		delete(app.taskMap, taskID)
-		log.Logger().Info("task removed",
-			zap.String("appID", app.applicationID),
-			zap.String("taskID", taskID))
-		return nil
+	if _, ok := app.taskMap[taskID]; !ok {
+		log.Logger().Debug("Attempted to remove non-existent task", zap.String("taskID", taskID))
+		return
 	}
-	return fmt.Errorf("task %s is not found in application %s",
-		taskID, app.applicationID)
+	delete(app.taskMap, taskID)
+	log.Logger().Info("task removed",
+		zap.String("appID", app.applicationID),
+		zap.String("taskID", taskID))
 }
 
 func (app *Application) GetApplicationState() string {

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -692,8 +692,11 @@ func (ctx *Context) RemoveTask(appID, taskID string) error {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
 	if app, ok := ctx.applications[appID]; ok {
-		app.removeTask(taskID)
-		return nil
+		err := app.removeTask(taskID)
+		if err != nil {
+			log.Logger().Info(" not found, it has been deleted",
+				zap.String("task", taskID))
+		}
 	}
 	return nil
 }

--- a/pkg/cache/context.go
+++ b/pkg/cache/context.go
@@ -660,11 +660,8 @@ func (ctx *Context) RemoveApplication(appID string) error {
 func (ctx *Context) RemoveApplicationInternal(appID string) error {
 	ctx.lock.Lock()
 	defer ctx.lock.Unlock()
-	if _, exist := ctx.applications[appID]; exist {
-		delete(ctx.applications, appID)
-		return nil
-	}
-	return fmt.Errorf("application %s is not found in the context", appID)
+	delete(ctx.applications, appID)
+	return nil
 }
 
 // this implements ApplicationManagementProtocol
@@ -695,9 +692,10 @@ func (ctx *Context) RemoveTask(appID, taskID string) error {
 	ctx.lock.RLock()
 	defer ctx.lock.RUnlock()
 	if app, ok := ctx.applications[appID]; ok {
-		return app.removeTask(taskID)
+		app.removeTask(taskID)
+		return nil
 	}
-	return fmt.Errorf("application %s is not found in the context", appID)
+	return nil
 }
 
 func (ctx *Context) getTask(appID string, taskID string) (*Task, error) {

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -223,7 +223,7 @@ func TestRemoveApplicationInternal(t *testing.T) {
 	assert.Equal(t, len(context.applications), 2)
 	// remove non-exist app
 	err := context.RemoveApplicationInternal("app00003")
-	assert.Assert(t, err != nil)
+	assert.Assert(t, err == nil)
 	assert.Equal(t, len(context.applications), 2)
 	// remove app1
 	err = context.RemoveApplicationInternal(appID1)
@@ -723,12 +723,12 @@ func TestRemoveTask(t *testing.T) {
 	// try to remove a non-exist task
 	// this should fail
 	err := context.RemoveTask("app00001", "non-exist-task")
-	assert.Assert(t, err != nil)
+	assert.Assert(t, err == nil)
 
 	// try to remove a task from non-exist application
 	// this should also fail
 	err = context.RemoveTask("app-non-exist", "task00001")
-	assert.Assert(t, err != nil)
+	assert.Assert(t, err == nil)
 
 	// this should success
 	err = context.RemoveTask("app00001", "task00001")

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -221,19 +221,19 @@ func TestRemoveApplicationInternal(t *testing.T) {
 	context.applications[appID1] = app1
 	context.applications[appID2] = app2
 	assert.Equal(t, len(context.applications), 2)
+
 	// remove non-exist app
-	err := context.RemoveApplicationInternal("app00003")
-	assert.Assert(t, err == nil)
+	context.RemoveApplicationInternal("app00003")
 	assert.Equal(t, len(context.applications), 2)
+
 	// remove app1
-	err = context.RemoveApplicationInternal(appID1)
-	assert.NilError(t, err)
+	context.RemoveApplicationInternal(appID1)
 	assert.Equal(t, len(context.applications), 1)
 	_, ok := context.applications[appID1]
 	assert.Equal(t, ok, false)
+
 	// remove app2
-	err = context.RemoveApplicationInternal(appID2)
-	assert.NilError(t, err)
+	context.RemoveApplicationInternal(appID2)
 	assert.Equal(t, len(context.applications), 0)
 	_, ok = context.applications[appID2]
 	assert.Equal(t, ok, false)
@@ -721,23 +721,21 @@ func TestRemoveTask(t *testing.T) {
 	assert.Equal(t, len(app.GetNewTasks()), 2)
 
 	// try to remove a non-exist task
-	err := context.RemoveTask("app00001", "non-exist-task")
-	assert.Assert(t, err == nil)
+	context.RemoveTask("app00001", "non-exist-task")
+	assert.Equal(t, len(app.GetNewTasks()), 2)
 
 	// try to remove a task from non-exist application
-	err = context.RemoveTask("app-non-exist", "task00001")
-	assert.Assert(t, err == nil)
+	context.RemoveTask("app-non-exist", "task00001")
+	assert.Equal(t, len(app.GetNewTasks()), 2)
 
 	// this should success
-	err = context.RemoveTask("app00001", "task00001")
-	assert.Assert(t, err == nil)
+	context.RemoveTask("app00001", "task00001")
 
 	// now only 1 task left
 	assert.Equal(t, len(app.GetNewTasks()), 1)
 
 	// this should success
-	err = context.RemoveTask("app00001", "task00002")
-	assert.Assert(t, err == nil)
+	context.RemoveTask("app00001", "task00002")
 
 	// now there is no task left
 	assert.Equal(t, len(app.GetNewTasks()), 0)

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -721,12 +721,10 @@ func TestRemoveTask(t *testing.T) {
 	assert.Equal(t, len(app.GetNewTasks()), 2)
 
 	// try to remove a non-exist task
-	// this should fail
 	err := context.RemoveTask("app00001", "non-exist-task")
 	assert.Assert(t, err == nil)
 
 	// try to remove a task from non-exist application
-	// this should also fail
 	err = context.RemoveTask("app-non-exist", "task00001")
 	assert.Assert(t, err == nil)
 

--- a/pkg/callback/scheduler_callback.go
+++ b/pkg/callback/scheduler_callback.go
@@ -135,10 +135,7 @@ func (callback *AsyncRMCallback) UpdateApplication(response *si.ApplicationRespo
 			zap.String("new status", updated.State))
 		switch updated.State {
 		case events.States().Application.Completed:
-			err := callback.context.RemoveApplicationInternal(updated.ApplicationID)
-			if err != nil {
-				log.Logger().Error("failed to delete application", zap.Error(err))
-			}
+			callback.context.RemoveApplicationInternal(updated.ApplicationID)
 		case events.States().Application.Resuming:
 			app := callback.context.GetApplication(updated.ApplicationID)
 			if app != nil && app.GetApplicationState() == events.States().Application.Reserving {

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -136,8 +136,7 @@ partitions:
 
 	// remove the application
 	// remove task first or removeApplication will fail
-	err = cluster.context.RemoveTask(appID, "task0001")
-	assert.Assert(t, err == nil)
+	cluster.context.RemoveTask(appID, "task0001")
 	err = cluster.removeApplication(appID)
 	assert.Assert(t, err == nil)
 


### PR DESCRIPTION
### What is this PR for?
The shim context RemoveApplicationInternal and RemoveTask should not return an error if the application or task is not found.

I set the return value of RemoveApplicationInternal and RemoveTask to nil, so that no matter whether the task or application to be deleted exists or not, it will not return error.
Modify TestRemoveApplicationInternal and TestRemoveTask in context.go as expected.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
(https://issues.apache.org/jira/browse/YUNIKORN-1101)

### How should this be tested?
use "make test" command
### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
