### PR TITLE
[YUNIKORN-1111] Run yunikorn as non-root user (shim)

### DIFF
--- a/deployments/image/admission/Dockerfile
+++ b/deployments/image/admission/Dockerfile
@@ -17,5 +17,16 @@
 
 FROM alpine:latest
 
-ADD scheduler-admission-controller /scheduler-admission-controller
-ENTRYPOINT ["./scheduler-admission-controller"]
+RUN addgroup -S -g 4444 yunikorn && \
+    adduser -S -h /opt/yunikorn/work -G yunikorn -u 4444 yunikorn -s /bin/sh && \
+    mkdir -p /opt/yunikorn/bin /opt/yunikorn/work && \
+    chown -R yunikorn:yunikorn /opt/yunikorn/work && \
+    chmod 755 /opt/yunikorn/work
+
+ADD scheduler-admission-controller /opt/yunikorn/bin/scheduler-admission-controller
+
+RUN chmod 755 /opt/yunikorn/bin/scheduler-admission-controller
+
+WORKDIR /opt/yunikorn/work
+USER yunikorn
+ENTRYPOINT /opt/yunikorn/bin/scheduler-admission-controller

--- a/deployments/image/configmap/Dockerfile
+++ b/deployments/image/configmap/Dockerfile
@@ -17,9 +17,16 @@
 
 FROM alpine:latest
 
-# scheduler binary
-ADD k8s_yunikorn_scheduler /k8s_yunikorn_scheduler
-WORKDIR /
+RUN addgroup -S -g 4444 yunikorn && \
+    adduser -S -h /opt/yunikorn/work -G yunikorn -u 4444 yunikorn -s /bin/sh && \
+    mkdir -p /opt/yunikorn/bin /opt/yunikorn/work && \
+    chown -R yunikorn:yunikorn /opt/yunikorn/work && \
+    chmod 755 /opt/yunikorn/work
+
+ADD k8s_yunikorn_scheduler /opt/yunikorn/bin/k8s_yunikorn_scheduler
+ADD start-yunikorn.sh /opt/yunikorn/bin/start-yunikorn.sh
+RUN chmod 755 /opt/yunikorn/bin/*
+
 ENV CLUSTER_ID "mycluster"
 ENV CLUSTER_VERSION "latest"
 ENV POLICY_GROUP "queues"
@@ -35,19 +42,7 @@ ENV OPERATOR_PLUGINS "general"
 ENV ENABLE_CONFIG_HOT_REFRESH "true"
 ENV DISABLE_GANG_SCHEDULING "false"
 ENV USER_LABEL_KEY "yunikorn.apache.org/username"
-ENTRYPOINT ["sh", "-c", "/k8s_yunikorn_scheduler \
--clusterId=${CLUSTER_ID} \
--clusterVersion=${CLUSTER_VERSION} \
--policyGroup=${POLICY_GROUP} \
--interval=${SCHEDULING_INTERVAL} \
--logLevel=${LOG_LEVEL} \
--logEncoding=${LOG_ENCODING} \
--volumeBindTimeout=${VOLUME_BINDING_TIMEOUT} \
--eventChannelCapacity=${EVENT_CHANNEL_CAPACITY} \
--dispatchTimeout=${DISPATCHER_TIMEOUT} \
--kubeQPS=${KUBE_CLIENT_QPS} \
--kubeBurst=${KUBE_CLIENT_BURST} \
--operatorPlugins=${OPERATOR_PLUGINS} \
--enableConfigHotRefresh=${ENABLE_CONFIG_HOT_REFRESH} \
--disableGangScheduling=${DISABLE_GANG_SCHEDULING} \
--userLabelKey=${USER_LABEL_KEY}"]
+
+WORKDIR /opt/yunikorn/work
+USER yunikorn
+ENTRYPOINT /opt/yunikorn/bin/start-yunikorn.sh

--- a/deployments/image/configmap/start-yunikorn.sh
+++ b/deployments/image/configmap/start-yunikorn.sh
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd /opt/yunikorn/work
 exec /opt/yunikorn/bin/k8s_yunikorn_scheduler \
   -clusterId="${CLUSTER_ID}" \

--- a/deployments/image/configmap/start-yunikorn.sh
+++ b/deployments/image/configmap/start-yunikorn.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+cd /opt/yunikorn/work
+exec /opt/yunikorn/bin/k8s_yunikorn_scheduler \
+  -clusterId="${CLUSTER_ID}" \
+  -clusterVersion="${CLUSTER_VERSION}" \
+  -policyGroup="${POLICY_GROUP}" \
+  -interval="${SCHEDULING_INTERVAL}" \
+  -logLevel="${LOG_LEVEL}" \
+  -logEncoding="${LOG_ENCODING}" \
+  -volumeBindTimeout="${VOLUME_BINDING_TIMEOUT}" \
+  -eventChannelCapacity="${EVENT_CHANNEL_CAPACITY}" \
+  -dispatchTimeout="${DISPATCHER_TIMEOUT}" \
+  -kubeQPS="${KUBE_CLIENT_QPS}" \
+  -kubeBurst="${KUBE_CLIENT_BURST}" \
+  -operatorPlugins="${OPERATOR_PLUGINS}" \
+  -enableConfigHotRefresh="${ENABLE_CONFIG_HOT_REFRESH}" \
+  -disableGangScheduling="${DISABLE_GANG_SCHEDULING}" \
+  -userLabelKey="${USER_LABEL_KEY}"

--- a/deployments/image/plugin/Dockerfile
+++ b/deployments/image/plugin/Dockerfile
@@ -17,10 +17,17 @@
 
 FROM alpine:latest
 
-# scheduler binary
-ADD kube-scheduler /bin/kube-scheduler
-ADD scheduler-config.yaml /bin/scheduler-config.yaml
-WORKDIR /bin
+RUN addgroup -S -g 4444 yunikorn && \
+    adduser -S -h /opt/yunikorn/work -G yunikorn -u 4444 yunikorn -s /bin/sh && \
+    mkdir -p /opt/yunikorn/bin /opt/yunikorn/work && \
+    chown -R yunikorn:yunikorn /opt/yunikorn/work && \
+    chmod 755 /opt/yunikorn/work
+
+ADD kube-scheduler /opt/yunikorn/bin/kube-scheduler
+ADD start-yunikorn-plugin.sh /opt/yunikorn/bin/start-yunikorn-plugin.sh
+ADD scheduler-config.yaml /opt/yunikorn/work/scheduler-config.yaml
+RUN chmod 755 /opt/yunikorn/bin/*
+
 ENV CLUSTER_ID "mycluster"
 ENV CLUSTER_VERSION "latest"
 ENV POLICY_GROUP "queues"
@@ -41,23 +48,7 @@ ENV SCHEDULER_CONFIG "scheduler-config.yaml"
 ENV VERBOSITY "2"
 ENV SCHEDULER_NAME "yunikorn"
 
-ENTRYPOINT ["/bin/sh", "-c", "/bin/kube-scheduler \
---address=\"${ADDRESS}\" \
---leader-elect=\"${LEADER_ELECT}\" \
---config=\"${SCHEDULER_CONFIG}\" \
--v=\"${VERBOSITY}\" \
---scheduler-name=\"${SCHEDULER_NAME}\" \
---yk-cluster-id=\"${CLUSTER_ID}\" \
---yk-cluster-version=\"${CLUSTER_VERSION}\" \
---yk-policy-group=\"${POLICY_GROUP}\" \
---yk-scheduling-interval=\"${SCHEDULING_INTERVAL}\" \
---yk-log-level=\"${LOG_LEVEL}\" \
---yk-log-encoding=\"${LOG_ENCODING}\" \
---yk-event-channel-capacity=\"${EVENT_CHANNEL_CAPACITY}\" \
---yk-dispatcher-timeout=\"${DISPATCHER_TIMEOUT}\" \
---yk-kube-qps=\"${KUBE_CLIENT_QPS}\" \
---yk-kube-burst=\"${KUBE_CLIENT_BURST}\" \
---yk-enable-config-hot-refresh=\"${ENABLE_CONFIG_HOT_REFRESH}\" \
---yk-disable-gang-scheduling=\"${DISABLE_GANG_SCHEDULING}\" \
---yk-user-label-key=\"${USER_LABEL_KEY}\" \
---yk-scheduler-name=\"${SCHEDULER_NAME}\""]
+
+WORKDIR /opt/yunikorn/work
+USER yunikorn
+ENTRYPOINT /opt/yunikorn/bin/start-yunikorn-plugin.sh

--- a/deployments/image/plugin/start-yunikorn-plugin.sh
+++ b/deployments/image/plugin/start-yunikorn-plugin.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+cd /opt/yunikorn/work
+exec /opt/yunikorn/bin/kube-scheduler \
+  --address="${ADDRESS}" \
+  --leader-elect="${LEADER_ELECT}" \
+  --config="${SCHEDULER_CONFIG}" \
+  -v="${VERBOSITY}" \
+  --scheduler-name="${SCHEDULER_NAME}" \
+  --yk-cluster-id="${CLUSTER_ID}" \
+  --yk-cluster-version="${CLUSTER_VERSION}" \
+  --yk-policy-group="${POLICY_GROUP}" \
+  --yk-scheduling-interval="${SCHEDULING_INTERVAL}" \
+  --yk-log-level="${LOG_LEVEL}" \
+  --yk-log-encoding="${LOG_ENCODING}" \
+  --yk-event-channel-capacity="${EVENT_CHANNEL_CAPACITY}" \
+  --yk-dispatcher-timeout="${DISPATCHER_TIMEOUT}" \
+  --yk-kube-qps="${KUBE_CLIENT_QPS}" \
+  --yk-kube-burst="${KUBE_CLIENT_BURST}" \
+  --yk-enable-config-hot-refresh="${ENABLE_CONFIG_HOT_REFRESH}" \
+  --yk-disable-gang-scheduling="${DISABLE_GANG_SCHEDULING}" \
+  --yk-user-label-key="${USER_LABEL_KEY}" \
+  --yk-scheduler-name="${SCHEDULER_NAME}"

--- a/deployments/image/plugin/start-yunikorn-plugin.sh
+++ b/deployments/image/plugin/start-yunikorn-plugin.sh
@@ -1,4 +1,21 @@
 #!/bin/sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cd /opt/yunikorn/work
 exec /opt/yunikorn/bin/kube-scheduler \
   --address="${ADDRESS}" \


### PR DESCRIPTION
### What is this PR for?
Updates the docker images for YuniKorn to run as a non-root user. This increases security as we do not really need root access.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1111

### How should this be tested?
Local e2e tests continue to pass, and locally verified that containers run as non-root.

### Screenshots (if appropriate)
Scheduler:
<img width="793" alt="scheduler-non-root" src="https://user-images.githubusercontent.com/12699633/157509692-35be23c1-51ad-4049-9461-abe333b4364f.png">
Scheduler plugin:
<img width="802" alt="plugin-non-root" src="https://user-images.githubusercontent.com/12699633/157509712-c9e844c5-8923-4687-bb2d-bdb1d1f569fb.png">
Admission controller:
<img width="844" alt="admission-non-root" src="https://user-images.githubusercontent.com/12699633/157509722-00683480-0ac9-4fca-9d1f-f670ea350194.png">


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
