### PR TITLE
[YUNIKORN-1112] Use K8s ENV vars to locate yunikorn service from within admission controller

### DIFF
--- a/pkg/plugin/admissioncontrollers/webhook/webhook.go
+++ b/pkg/plugin/admissioncontrollers/webhook/webhook.go
@@ -37,6 +37,8 @@ const (
 	HTTPPort                             = 9089
 	policyGroupEnvVarName                = "POLICY_GROUP"
 	schedulerServiceAddressEnvVarName    = "SCHEDULER_SERVICE_ADDRESS"
+	yunikornServiceHostEnvVarName        = "YUNIKORN_SERVICE_SERVICE_HOST"
+	yunikornServicePortEnvVarName        = "YUNIKORN_SERVICE_SERVICE_PORT"
 	schedulerValidateConfURLPattern      = "http://%s/ws/v1/validate-conf"
 	admissionControllerNamespace         = "ADMISSION_CONTROLLER_NAMESPACE"
 	admissionControllerService           = "ADMISSION_CONTROLLER_SERVICE"
@@ -96,7 +98,15 @@ func main() {
 	if policyGroup == "" {
 		policyGroup = conf.DefaultPolicyGroup
 	}
-	schedulerServiceAddress := os.Getenv(schedulerServiceAddressEnvVarName)
+
+	var schedulerServiceAddress string
+	ykHost, hostOk := os.LookupEnv(yunikornServiceHostEnvVarName)
+	ykPort, portOk := os.LookupEnv(yunikornServicePortEnvVarName)
+	if hostOk && portOk {
+		schedulerServiceAddress = fmt.Sprintf("%s:%s", ykHost, ykPort)
+	} else {
+		schedulerServiceAddress = os.Getenv(schedulerServiceAddressEnvVarName)
+	}
 
 	webHook, err := initAdmissionController(
 		fmt.Sprintf("%s.yaml", policyGroup),


### PR DESCRIPTION
### What is this PR for?
In certain networking environments (such as EKS with Calico), the yunikorn-service DNS entry is unavailable within the admission controller when running in the host network. However, we can use Kubernetes ENV vars to locate the service. 

This patch uses `YUNIKORN_SERVICE_SERVICE_HOST` and `YUNIKORN_SERVICE_SERVICE_PORT` in preference to `SCHEDULER_SERVICE_ADDRESS` if present.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1112

### How should this be tested?
Verified with local deployment using the new syntax.

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
