### PR TITLE
[YUNIKORN-1105] Use absolute units for memory

### DIFF
--- a/pkg/cache/application_test.go
+++ b/pkg/cache/application_test.go
@@ -664,12 +664,11 @@ func TestSetTaskGroupsAndSchedulingPolicy(t *testing.T) {
 	assert.Equal(t, tg2.Tolerations[0].Effect, v1.TaintEffectNoSchedule)
 	assert.Equal(t, tg2.Tolerations[0].TolerationSeconds, &duration)
 
-	// This is a weird calculation for memory as the request is rounded up before multiplying.
-	// TG1: 500Mi, 10 members: each member 525M -> total 5250M
-	// TG2: 1000Mi, 20 members: each member 1049M -> total 20980
-	// overall usage 5250M + 20980M -> 26230M. This will also be the queue usage so the correct handling
+	// TG1: 500Mi, 10 members -> total 5000Mi
+	// TG2: 1000Mi, 20 members -> total 20000Mi
+	// overall usage 5000Mi + 20000Mi = 25000Mi. This will also be the queue usage so the correct handling
 	// CPU is normal as it specifies milli cpu to start with
-	expectedPlaceholderAsk := common.NewResourceBuilder().AddResource(constants.Memory, 26230).AddResource(constants.CPU, 25000).Build()
+	expectedPlaceholderAsk := common.NewResourceBuilder().AddResource(constants.Memory, 25000*1024*1024).AddResource(constants.CPU, 25000).Build()
 	actualPlaceholderAsk := app.getPlaceholderAsk()
 	assert.DeepEqual(t, actualPlaceholderAsk, expectedPlaceholderAsk)
 }

--- a/pkg/cache/context_test.go
+++ b/pkg/cache/context_test.go
@@ -1055,7 +1055,7 @@ func TestAddApplicationsWithTags(t *testing.T) {
 		if quotaRes.Resources == nil || quotaRes.Resources["memory"] == nil {
 			t.Fatalf("could not find parsed memory resource from annotation")
 		}
-		assert.Equal(t, quotaRes.Resources["memory"].Value, int64(256))
+		assert.Equal(t, quotaRes.Resources["memory"].Value, int64(256*1000*1000))
 	} else {
 		t.Fatalf("resource parsing failed")
 	}

--- a/pkg/cache/node_coordinator_test.go
+++ b/pkg/cache/node_coordinator_test.go
@@ -84,9 +84,9 @@ func TestUpdatePod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host1)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
 		return nil
 	}
@@ -106,7 +106,7 @@ func TestUpdatePod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host1)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(0))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(0))
@@ -140,9 +140,9 @@ func TestUpdatePod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host2)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
 		return nil
 	}
@@ -162,7 +162,7 @@ func TestUpdatePod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host2)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(0))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(0))
@@ -206,9 +206,9 @@ func TestDeletePod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host1)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
 		return nil
 	}
@@ -254,9 +254,9 @@ func TestDeleteTerminatedPod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host1)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
-		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000))
+		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(1000*1000*1000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(500))
 		return nil
 	}
@@ -276,7 +276,7 @@ func TestDeleteTerminatedPod(t *testing.T) {
 		updatedNode := request.Nodes[0]
 		assert.Equal(t, updatedNode.NodeID, Host1)
 		assert.Equal(t, updatedNode.Action, si.NodeInfo_UPDATE)
-		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000))
+		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.Memory].Value, int64(10000*1000*1000))
 		assert.Equal(t, updatedNode.SchedulableResource.Resources[constants.CPU].Value, int64(10000))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.Memory].Value, int64(0))
 		assert.Equal(t, updatedNode.OccupiedResource.Resources[constants.CPU].Value, int64(0))

--- a/pkg/cache/nodes_test.go
+++ b/pkg/cache/nodes_test.go
@@ -42,7 +42,7 @@ func TestAddNode(t *testing.T) {
 	api := test.NewSchedulerAPIMock()
 
 	// register fn doesn't nothing than checking input
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024, 10000, false))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024*1000*1000, 10000, false))
 
 	nodes := newSchedulerNodes(api, NewTestSchedulerCache())
 	dispatcher.RegisterEventHandler(dispatcher.EventTypeNode, nodes.schedulerNodeEventHandler())
@@ -114,7 +114,7 @@ func TestUpdateNode(t *testing.T) {
 
 	// this function validates the new node can be added
 	// this verifies the shim sends the si.UpdateRequest to core with the new node info
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024, 10000, false))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024*1000*1000, 10000, false))
 
 	// add the node first
 	nodes.addNode(&oldNode)
@@ -157,7 +157,7 @@ func TestUpdateNode(t *testing.T) {
 		},
 	}
 
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048, 10000, false))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048*1000*1000, 10000, false))
 
 	nodes.updateNode(&oldNode, &newNode)
 	assert.Equal(t, api.GetRegisterCount(), int32(0))
@@ -179,7 +179,7 @@ func TestUpdateNode(t *testing.T) {
 		},
 	}
 
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048, 10000, true))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048*1000*1000, 10000, true))
 
 	nodes.updateNode(&oldNode, &newNode1)
 	assert.Equal(t, api.GetRegisterCount(), int32(0))
@@ -220,7 +220,7 @@ func TestUpdateWithoutNodeAdded(t *testing.T) {
 		},
 	}
 
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024, 10000, false))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 1024*1000*1000, 10000, false))
 
 	// directly trigger an update
 	// if the node was not seeing in the cache, we should see the node be added
@@ -249,7 +249,7 @@ func TestUpdateWithoutNodeAdded(t *testing.T) {
 		},
 	}
 
-	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048, 10000, false))
+	api.UpdateNodeFunction(getUpdateNodeFunction(t, "host0001", 2048*1000*1000, 10000, false))
 
 	nodes.updateNode(&oldNode, &newNode)
 	assert.Equal(t, api.GetRegisterCount(), int32(0))

--- a/pkg/cache/placeholder_test.go
+++ b/pkg/cache/placeholder_test.go
@@ -63,7 +63,7 @@ func TestNewPlaceholder(t *testing.T) {
 	assert.Equal(t, len(holder.pod.Annotations), 2)
 	assert.Equal(t, holder.pod.Annotations[constants.AnnotationTaskGroupName], app.taskGroups[0].Name)
 	assert.Equal(t, common.GetPodResource(holder.pod).Resources[constants.CPU].Value, int64(500))
-	assert.Equal(t, common.GetPodResource(holder.pod).Resources[constants.Memory].Value, int64(1024))
+	assert.Equal(t, common.GetPodResource(holder.pod).Resources[constants.Memory].Value, int64(1024*1000*1000))
 	assert.Equal(t, len(holder.pod.Spec.NodeSelector), 0)
 	assert.Equal(t, len(holder.pod.Spec.Tolerations), 0)
 	assert.Equal(t, holder.String(), "appID: app01, taskGroup: test-group-1, podName: test/ph-name")

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -63,7 +63,7 @@ func GetPodResource(pod *v1.Pod) (resource *si.Resource) {
 	// scheduled. Handle a QosBestEffort pod by setting a tiny memory value.
 	if qos.GetPodQOS(pod) == v1.PodQOSBestEffort {
 		resources := NewResourceBuilder()
-		resources.AddResource(constants.Memory, 1)
+		resources.AddResource(constants.Memory, 1000000)
 		return resources.Build()
 	}
 

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -130,7 +130,7 @@ func ParseResource(cpuStr, memStr string) *si.Resource {
 
 	if memStr != "" {
 		if mem, err := resource.ParseQuantity(memStr); err == nil {
-			result.AddResource(constants.Memory, mem.ScaledValue(resource.Mega))
+			result.AddResource(constants.Memory, mem.Value())
 		} else {
 			log.Logger().Error("failed to parse memory resource",
 				zap.String("memStr", memStr),
@@ -148,8 +148,6 @@ func GetTGResource(resMap map[string]resource.Quantity, members int64) *si.Resou
 		switch resName {
 		case v1.ResourceCPU.String():
 			result.AddResource(constants.CPU, members*resValue.MilliValue())
-		case v1.ResourceMemory.String():
-			result.AddResource(constants.Memory, members*resValue.ScaledValue(resource.Mega))
 		default:
 			result.AddResource(resName, members*resValue.Value())
 		}
@@ -161,9 +159,6 @@ func getResource(resourceList v1.ResourceList) *si.Resource {
 	resources := NewResourceBuilder()
 	for name, value := range resourceList {
 		switch name {
-		case v1.ResourceMemory:
-			memory := value.ScaledValue(resource.Mega)
-			resources.AddResource(constants.Memory, memory)
 		case v1.ResourceCPU:
 			vcore := value.MilliValue()
 			resources.AddResource(constants.CPU, vcore)

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -289,7 +289,7 @@ func TestBestEffortPod(t *testing.T) {
 	// best effort pod all resources are nil or zero
 	res := GetPodResource(pod)
 	assert.Equal(t, len(res.Resources), 1)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1000000))
 
 	// Add a resource to existing container (other than mem)
 	resources[v1.ResourceCPU] = resource.MustParse("1")
@@ -304,7 +304,7 @@ func TestBestEffortPod(t *testing.T) {
 
 	res = GetPodResource(pod)
 	assert.Equal(t, len(res.Resources), 1)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1000000))
 }
 
 func TestNodeResource(t *testing.T) {

--- a/pkg/common/resource_test.go
+++ b/pkg/common/resource_test.go
@@ -187,7 +187,7 @@ func TestParsePodResource(t *testing.T) {
 
 	// verify we get aggregated resource from containers
 	res := GetPodResource(pod)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1524))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(1524*1000*1000))
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(3000))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(5))
 
@@ -239,7 +239,7 @@ func TestParsePodResource(t *testing.T) {
 	// C2{1024mi, 5000m, 2}
 	// result {5120mi, 10000m, 4}
 	res = GetPodResource(pod)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(10000))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(10000000000))
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(5120))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(4))
 
@@ -256,7 +256,7 @@ func TestParsePodResource(t *testing.T) {
 	// sum of containers{5120mi, 7000m}
 	// result {5120mi, 10000m, 1}
 	res = GetPodResource(pod)
-	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(10000))
+	assert.Equal(t, res.Resources[constants.Memory].GetValue(), int64(10000000000))
 	assert.Equal(t, res.Resources[constants.CPU].GetValue(), int64(5120))
 	assert.Equal(t, res.Resources["nvidia.com/gpu"].GetValue(), int64(1))
 }
@@ -417,17 +417,17 @@ func TestParseResourceString(t *testing.T) {
 		{"-10", "", true, false, -10000, 0},
 		{"100m", "", true, false, 100, 0},
 		// memory values
-		{"", "65536", false, true, 0, 1},
-		{"", "129M", false, true, 0, 129},
-		{"", "123Mi", false, true, 0, 129},
-		{"", "128974848", false, true, 0, 129},
-		{"", "1G", false, true, 0, 1000},
-		{"", "1Gi", false, true, 0, 1074},
-		{"", "1T", false, true, 0, 1000000},
-		{"", "1P", false, true, 0, 1000000000},
-		{"", "1E", false, true, 0, 1000000000000},
+		{"", "65536", false, true, 0, 65536},
+		{"", "129M", false, true, 0, 129 * 1000 * 1000},
+		{"", "123Mi", false, true, 0, 123 * 1024 * 1024},
+		{"", "128974848", false, true, 0, 128974848},
+		{"", "1G", false, true, 0, 1000 * 1000 * 1000},
+		{"", "1Gi", false, true, 0, 1024 * 1024 * 1024},
+		{"", "1T", false, true, 0, 1000 * 1000 * 1000 * 1000},
+		{"", "1P", false, true, 0, 1000 * 1000 * 1000 * 1000 * 1000},
+		{"", "1E", false, true, 0, 1000 * 1000 * 1000 * 1000 * 1000 * 1000},
 		// cpu and memory
-		{"0.5", "64M", true, true, 500, 64},
+		{"0.5", "64M", true, true, 500, 64 * 1000 * 1000},
 		// parsing error on cpu
 		{"xyz", "64M", false, false, 0, 0},
 		// parsing error on memory

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -90,7 +90,7 @@ func TestGetNamespaceQuotaFromAnnotation(t *testing.T) {
 				},
 			},
 		}, common.NewResourceBuilder().
-			AddResource(constants.Memory, 128).
+			AddResource(constants.Memory, 128*1000*1000).
 			Build()},
 		{&v1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -133,7 +133,7 @@ func TestGetNamespaceQuotaFromAnnotation(t *testing.T) {
 			},
 		}, common.NewResourceBuilder().
 			AddResource(constants.CPU, 1000).
-			AddResource(constants.Memory, 64).
+			AddResource(constants.Memory, 64*1000*1000).
 			Build()},
 	}
 

--- a/pkg/shim/scheduler_test.go
+++ b/pkg/shim/scheduler_test.go
@@ -50,10 +50,10 @@ partitions:
           - name: a
             resources:
               guaranteed:
-                memory: 100
+                memory: 100000000
                 vcore: 10
               max:
-                memory: 150
+                memory: 150000000
                 vcore: 20
 `
 	// init and register scheduler
@@ -66,15 +66,15 @@ partitions:
 	cluster.waitForSchedulerState(t, events.States().Scheduler.Running)
 
 	// register nodes
-	err := cluster.addNode("test.host.01", 100, 10)
+	err := cluster.addNode("test.host.01", 100000000, 10)
 	assert.NilError(t, err, "add node failed")
-	err = cluster.addNode("test.host.02", 100, 10)
+	err = cluster.addNode("test.host.02", 100000000, 10)
 	assert.NilError(t, err, "add node failed")
 
 	// create app and tasks
 	cluster.addApplication("app0001", "root.a")
 	taskResource := common.NewResourceBuilder().
-		AddResource(constants.Memory, 10).
+		AddResource(constants.Memory, 10000000).
 		AddResource(constants.CPU, 1).
 		Build()
 	cluster.addTask("app0001", "task0001", taskResource)
@@ -98,10 +98,10 @@ partitions:
           - name: a
             resources:
               guaranteed:
-                memory: 100
+                memory: 100000000
                 vcore: 10
               max:
-                memory: 150
+                memory: 150000000
                 vcore: 20
 `
 	// init and register scheduler
@@ -114,9 +114,9 @@ partitions:
 	cluster.waitForSchedulerState(t, events.States().Scheduler.Running)
 
 	// register nodes
-	err := cluster.addNode("test.host.01", 100, 10)
+	err := cluster.addNode("test.host.01", 100000000, 10)
 	assert.NilError(t, err)
-	err = cluster.addNode("test.host.02", 100, 10)
+	err = cluster.addNode("test.host.02", 100000000, 10)
 	assert.NilError(t, err)
 
 	// add app to context
@@ -125,7 +125,7 @@ partitions:
 
 	// create app and tasks
 	taskResource := common.NewResourceBuilder().
-		AddResource(constants.Memory, 10).
+		AddResource(constants.Memory, 10000000).
 		AddResource(constants.CPU, 1).
 		Build()
 	cluster.addTask(appID, "task0001", taskResource)
@@ -182,10 +182,10 @@ partitions:
            name: a
            resources:
              guaranteed:
-               memory: 100
+               memory: 100000000
                vcore: 10
              max:
-               memory: 100
+               memory: 100000000
                vcore: 10
 `
 	// init and register scheduler
@@ -206,15 +206,15 @@ partitions:
 	cluster.waitForSchedulerState(t, events.States().Scheduler.Running)
 
 	// register nodes
-	err := cluster.addNode("test.host.01", 100, 10)
+	err := cluster.addNode("test.host.01", 100000000, 10)
 	assert.NilError(t, err, "add node failed")
-	err = cluster.addNode("test.host.02", 100, 10)
+	err = cluster.addNode("test.host.02", 100000000, 10)
 	assert.NilError(t, err, "add node failed")
 
 	// create app and tasks
 	cluster.addApplication("app0001", "root.a")
 	taskResource := common.NewResourceBuilder().
-		AddResource(constants.Memory, 50).
+		AddResource(constants.Memory, 50000000).
 		AddResource(constants.CPU, 5).
 		Build()
 	cluster.addTask("app0001", "task0001", taskResource)

--- a/test/e2e/basic_scheduling/basic_scheduling_test.go
+++ b/test/e2e/basic_scheduling/basic_scheduling_test.go
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe("", func() {
 		ginkgo.By("Deploy the sleep pod to the development namespace")
 		sleepRespPod, err = kClient.CreatePod(common.InitSleepPod(sleepPodConfigs), dev)
 		gomega.Ω(err).NotTo(gomega.HaveOccurred())
-		//Wait for pod to move to running state
+		// Wait for pod to move to running state
 		err = kClient.WaitForPodBySelectorRunning(dev,
 			fmt.Sprintf("app=%s", sleepRespPod.ObjectMeta.Labels["app"]),
 			10)
@@ -113,9 +113,9 @@ var _ = ginkgo.Describe("", func() {
 		gomega.Ω(allocations["applicationId"]).To(gomega.Equal(sleepRespPod.ObjectMeta.Labels["applicationId"]))
 		gomega.Ω(allocations["queueName"]).To(gomega.ContainSubstring(sleepRespPod.ObjectMeta.Namespace))
 		core := strconv.FormatInt(sleepRespPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(), 10)
-		mem := sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().String()
+		mem := strconv.FormatInt(sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().Value(), 10)
 		matches := r.FindStringSubmatch(allocations["resource"].(string))
-		gomega.Ω(matches[1] + "M").To(gomega.Equal(mem))
+		gomega.Ω(matches[1]).To(gomega.Equal(mem))
 		gomega.Ω(matches[2]).To(gomega.ContainSubstring(core))
 	})
 

--- a/test/e2e/queue_quota_mgmt/queue_quota_mgmt_test.go
+++ b/test/e2e/queue_quota_mgmt/queue_quota_mgmt_test.go
@@ -73,7 +73,7 @@ var _ = Describe("", func() {
 		annotations[maxMemAnnotation] = strconv.FormatInt(maxMem, 10) + "M"
 
 		ns = "ns-" + common.RandSeq(10)
-		By(fmt.Sprintf("create %s namespace with maxCPU: %d and maxMem: %d", ns, maxCPU, maxMem))
+		By(fmt.Sprintf("create %s namespace with maxCPU: %dm and maxMem: %dM", ns, maxCPU, maxMem))
 		ns1, err1 := kClient.CreateNamespace(ns, annotations)
 		Ω(err1).NotTo(HaveOccurred())
 		Ω(ns1.Status.Phase).To(Equal(v1.NamespaceActive))
@@ -108,11 +108,11 @@ var _ = Describe("", func() {
 
 			By(fmt.Sprintf("App-%d: Verify max capacity on the queue is accurate", iter))
 			Ω(maxResource.GetVCPU()).Should(Equal(strconv.FormatInt(maxCPU, 10)))
-			Ω(maxResource.GetMemory()).Should(Equal(strconv.FormatInt(maxMem, 10)))
+			Ω(maxResource.GetMemory()).Should(Equal(strconv.FormatInt(maxMem*1000*1000, 10)))
 
 			By(fmt.Sprintf("App-%d: Verify used capacity on the queue is accurate after 1st pod deployment", iter))
 			Ω(usedResource.GetVCPU()).Should(Equal(strconv.FormatInt(reqCPU*iter, 10)))
-			Ω(usedResource.GetMemory()).Should(Equal(strconv.FormatInt(reqMem*iter, 10)))
+			Ω(usedResource.GetMemory()).Should(Equal(strconv.FormatInt(reqMem*iter*1000*1000, 10)))
 
 			var perctCPU = strconv.FormatFloat(math.Floor((float64(reqCPU*iter)/float64(maxCPU))*100), 'g', -4, 64)
 			var perctMem = strconv.FormatFloat(math.Floor((float64(reqMem*iter)/float64(maxMem))*100), 'g', -4, 64)
@@ -130,7 +130,7 @@ var _ = Describe("", func() {
 		pods = append(pods, sleepObj.Name)
 
 		By(fmt.Sprintf("App-4: Verify app:%s in accepted state", sleepObj.Name))
-		//Wait for pod to move to accepted state
+		// Wait for pod to move to accepted state
 		err = restClient.WaitForAppStateTransition(sleepRespPod.ObjectMeta.Labels["applicationId"],
 			yunikorn.States().Application.Accepted,
 			120)
@@ -141,7 +141,7 @@ var _ = Describe("", func() {
 		Ω(err).NotTo(HaveOccurred())
 
 		By(fmt.Sprintf("App-1: Wait for 1st app:%s to complete, to make enough capacity to run the last app", pods[0]))
-		//Wait for pod to move to accepted state
+		// Wait for pod to move to accepted state
 		err = kClient.WaitForPodSucceeded(ns, pods[0], time.Duration(360)*time.Second)
 		Ω(err).NotTo(HaveOccurred())
 
@@ -185,11 +185,11 @@ var _ = Describe("", func() {
 	// Hierarchical Queues - Quota enforcement
 	// For now, these cases are skipped
 	PIt("Verify_Child_Max_Resource_Must_Be_Less_Than_Parent_Max", func() {
-		//P2 case - addressed later
+		// P2 case - addressed later
 	})
 
 	PIt("Verify_Sum_Of_All_Child_Resource_Must_Be_Less_Than_Parent_Max", func() {
-		//P2 case - addressed later
+		// P2 case - addressed later
 	})
 
 	AfterEach(func() {

--- a/test/e2e/state_aware_app_scheduling/fallback_test.go
+++ b/test/e2e/state_aware_app_scheduling/fallback_test.go
@@ -55,7 +55,7 @@ var _ = Describe("FallbackTest:", func() {
 		sleepPodConf := common.SleepPodConfig{Name: "sleepjob", NS: ns, Time: 600}
 		sleepRespPod, err = kClient.CreatePod(common.InitSleepPod(sleepPodConf), ns)
 		Ω(err).NotTo(HaveOccurred())
-		//Wait for pod to move to running state
+		// Wait for pod to move to running state
 	})
 
 	It("Verify_App_In_Starting_State", func() {
@@ -94,9 +94,9 @@ var _ = Describe("FallbackTest:", func() {
 		Ω(allocations["applicationId"]).To(Equal(sleepRespPod.ObjectMeta.Labels["applicationId"]))
 		Ω(allocations["queueName"]).To(ContainSubstring(sleepRespPod.ObjectMeta.Namespace))
 		core := strconv.FormatInt(sleepRespPod.Spec.Containers[0].Resources.Requests.Cpu().MilliValue(), 10)
-		mem := sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().String()
+		mem := strconv.FormatInt(sleepRespPod.Spec.Containers[0].Resources.Requests.Memory().Value(), 10)
 		matches := r.FindStringSubmatch(allocations["resource"].(string))
-		Ω(matches[1] + "M").To(Equal(mem))
+		Ω(matches[1]).To(Equal(mem))
 		Ω(matches[2]).To(ContainSubstring(core))
 	}, 360)
 


### PR DESCRIPTION
### What is this PR for?
Switch to using absolute units (bytes) for memory instead of megabytes (10^6). This avoids rounding errors within the scheduler.

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1105

### How should this be tested?
unit tests updated

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [x] - There is breaking changes for older versions.
* [x] - It needs documentation.
