### PR TITLE
[YUNIKORN-1123] UpdateNode may cause the scheduler to crash

### DIFF
--- a/pkg/cache/nodes.go
+++ b/pkg/cache/nodes.go
@@ -197,7 +197,7 @@ func (nc *schedulerNodes) updateNode(oldNode, newNode *v1.Node) {
 	}
 
 	log.Logger().Info("Node's ready status flag", zap.String("Node name", newNode.Name),
-		zap.Bool("ready", ready), zap.Bool("ready1111", cachedNode.ready))
+		zap.Bool("ready", ready))
 	request := common.CreateUpdateRequestForUpdatedNode(newNode.Name, cachedNode.capacity,
 		cachedNode.occupied, cachedNode.ready)
 	log.Logger().Info("report updated nodes to scheduler", zap.Any("request", request))

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -192,6 +192,7 @@ func CreateUpdateRequestForDeleteOrRestoreNode(nodeID string, action si.NodeInfo
 	nodeInfo := &si.NodeInfo{
 		NodeID: nodeID,
 		Action: action,
+		Attributes: make(map[string]string),
 	}
 
 	deletedNodes[0] = nodeInfo

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -237,23 +237,25 @@ func TestCreateUpdateRequestForUpdatedNode(t *testing.T) {
 
 func TestCreateUpdateRequestForDeleteNode(t *testing.T) {
 	action := si.NodeInfo_DECOMISSION
+	// asserting against this empty map ensures core doesn't have any issues
+	attributes := make(map[string]string)
 	request := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action)
 	assert.Equal(t, len(request.Nodes), 1)
 	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request.Nodes[0].Action, action)
-	assert.Equal(t, len(request.Nodes[0].Attributes), 0)
+	assert.DeepEqual(t, request.Nodes[0].Attributes, attributes)
 
 	action1 := si.NodeInfo_DRAIN_NODE
 	request1 := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action1)
 	assert.Equal(t, len(request1.Nodes), 1)
 	assert.Equal(t, request1.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request1.Nodes[0].Action, action1)
-	assert.Equal(t, len(request1.Nodes[0].Attributes), 0)
+	assert.DeepEqual(t, request1.Nodes[0].Attributes, attributes)
 
 	action2 := si.NodeInfo_DRAIN_TO_SCHEDULABLE
 	request2 := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action2)
 	assert.Equal(t, len(request2.Nodes), 1)
 	assert.Equal(t, request2.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request2.Nodes[0].Action, action2)
-	assert.Equal(t, len(request2.Nodes[0].Attributes), 0)
+	assert.DeepEqual(t, request2.Nodes[0].Attributes, attributes)
 }


### PR DESCRIPTION
### What is this PR for?
Sending UpdateNode request without empty nodeAttributes map to decommission the node causes panic on the core side. This bug has been caused while doing clean up as discussed in https://issues.apache.org/jira/browse/YUNIKORN-1090. This pr fixes the problem just by reverting that piece to its original state. 

### What type of PR is it?
* [ ] - Bug Fix

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1123

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
