### PR TITLE
[YUNIKORN-1124] Avoid passing empty nodeAttributes in UpdateNode request

### DIFF
--- a/pkg/cache/node.go
+++ b/pkg/cache/node.go
@@ -167,8 +167,7 @@ func (n *SchedulerNode) handleNodeRecovery(event *fsm.Event) {
 		zap.String("nodeID", n.name),
 		zap.Bool("schedulable", n.schedulable))
 
-	nodeRequest := common.CreateUpdateRequestForNewNode(n.name, n.capacity, n.occupied, n.existingAllocations,
-		n.labels, n.ready)
+	nodeRequest := common.CreateUpdateRequestForNewNode(n.name, n.capacity, n.existingAllocations, n.ready)
 
 	// send node request to scheduler-core
 	if err := n.schedulerAPI.UpdateNode(&nodeRequest); err != nil {

--- a/pkg/common/si_helper.go
+++ b/pkg/common/si_helper.go
@@ -135,19 +135,17 @@ func CreateReleaseAllocationRequestForTask(appID, allocUUID, partition, terminat
 }
 
 // CreateUpdateRequestForNewNode builds a NodeRequest for new node addition and restoring existing node
-func CreateUpdateRequestForNewNode(nodeID string, capacity *si.Resource, occupied *si.Resource,
-	existingAllocations []*si.Allocation, labels string, ready bool) si.NodeRequest {
+func CreateUpdateRequestForNewNode(nodeID string, capacity *si.Resource, existingAllocations []*si.Allocation,
+	ready bool) si.NodeRequest {
 	// Use node's name as the NodeID, this is because when bind pod to node,
 	// name of node is required but uid is optional.
 	nodeInfo := &si.NodeInfo{
 		NodeID:              nodeID,
 		SchedulableResource: capacity,
-		OccupiedResource:    occupied,
 		Attributes: map[string]string{
-			constants.DefaultNodeAttributeHostNameKey:   nodeID,
-			constants.DefaultNodeAttributeRackNameKey:   constants.DefaultRackName,
-			constants.DefaultNodeAttributeNodeLabelsKey: labels,
-			constants.NodeReadyAttribute:                strconv.FormatBool(ready),
+			constants.DefaultNodeAttributeHostNameKey: nodeID,
+			constants.DefaultNodeAttributeRackNameKey: constants.DefaultRackName,
+			constants.NodeReadyAttribute:              strconv.FormatBool(ready),
 		},
 		ExistingAllocations: existingAllocations,
 		Action:              si.NodeInfo_CREATE,
@@ -190,9 +188,8 @@ func CreateUpdateRequestForUpdatedNode(nodeID string, capacity *si.Resource, occ
 func CreateUpdateRequestForDeleteOrRestoreNode(nodeID string, action si.NodeInfo_ActionFromRM) si.NodeRequest {
 	deletedNodes := make([]*si.NodeInfo, 1)
 	nodeInfo := &si.NodeInfo{
-		NodeID:     nodeID,
-		Action:     action,
-		Attributes: make(map[string]string),
+		NodeID: nodeID,
+		Action: action,
 	}
 
 	deletedNodes[0] = nodeInfo

--- a/pkg/common/si_helper_test.go
+++ b/pkg/common/si_helper_test.go
@@ -206,19 +206,15 @@ func TestCreateTagsForTask(t *testing.T) {
 
 func TestCreateUpdateRequestForNewNode(t *testing.T) {
 	capacity := NewResourceBuilder().AddResource(constants.Memory, 200).AddResource(constants.CPU, 2).Build()
-	occupied := NewResourceBuilder().AddResource(constants.Memory, 50).AddResource(constants.CPU, 1).Build()
 	var existingAllocations []*si.Allocation
-	labels := ""
 	ready := true
-	request := CreateUpdateRequestForNewNode(nodeID, capacity, occupied, existingAllocations, labels, ready)
+	request := CreateUpdateRequestForNewNode(nodeID, capacity, existingAllocations, ready)
 	assert.Equal(t, len(request.Nodes), 1)
 	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request.Nodes[0].SchedulableResource, capacity)
-	assert.Equal(t, request.Nodes[0].OccupiedResource, occupied)
-	assert.Equal(t, len(request.Nodes[0].Attributes), 4)
+	assert.Equal(t, len(request.Nodes[0].Attributes), 3)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeHostNameKey], nodeID)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeRackNameKey], constants.DefaultRackName)
-	assert.Equal(t, request.Nodes[0].Attributes[constants.DefaultNodeAttributeNodeLabelsKey], labels)
 	assert.Equal(t, request.Nodes[0].Attributes[constants.NodeReadyAttribute], strconv.FormatBool(ready))
 }
 
@@ -238,24 +234,20 @@ func TestCreateUpdateRequestForUpdatedNode(t *testing.T) {
 func TestCreateUpdateRequestForDeleteNode(t *testing.T) {
 	action := si.NodeInfo_DECOMISSION
 	// asserting against this empty map ensures core doesn't have any issues
-	attributes := make(map[string]string)
 	request := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action)
 	assert.Equal(t, len(request.Nodes), 1)
 	assert.Equal(t, request.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request.Nodes[0].Action, action)
-	assert.DeepEqual(t, request.Nodes[0].Attributes, attributes)
 
 	action1 := si.NodeInfo_DRAIN_NODE
 	request1 := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action1)
 	assert.Equal(t, len(request1.Nodes), 1)
 	assert.Equal(t, request1.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request1.Nodes[0].Action, action1)
-	assert.DeepEqual(t, request1.Nodes[0].Attributes, attributes)
 
 	action2 := si.NodeInfo_DRAIN_TO_SCHEDULABLE
 	request2 := CreateUpdateRequestForDeleteOrRestoreNode(nodeID, action2)
 	assert.Equal(t, len(request2.Nodes), 1)
 	assert.Equal(t, request2.Nodes[0].NodeID, nodeID)
 	assert.Equal(t, request2.Nodes[0].Action, action2)
-	assert.DeepEqual(t, request2.Nodes[0].Attributes, attributes)
 }

--- a/pkg/shim/scheduler_mock_test.go
+++ b/pkg/shim/scheduler_mock_test.go
@@ -91,8 +91,7 @@ func (fc *MockScheduler) addNode(nodeName string, memory, cpu int64) error {
 		AddResource(constants.Memory, memory).
 		AddResource(constants.CPU, cpu).
 		Build()
-	request := common.CreateUpdateRequestForNewNode(nodeName, nodeResource, nil,
-		nil, "", true)
+	request := common.CreateUpdateRequestForNewNode(nodeName, nodeResource, nil, true)
 	fmt.Printf("report new nodes to scheduler, request: %s", request.String())
 	return fc.apiProvider.GetAPIs().SchedulerAPI.UpdateNode(&request)
 }


### PR DESCRIPTION
### What is this PR for?
Shim do not pass the following:
1. Empty NodeAttributes map as part of UpdateRequest (for delete, restore & decommissioning actions). 
2. Removed OccupiedResource and labels from UpdateRequest (create action) as they are not required on the core side

### What type of PR is it?
* [ ] - Improvement

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1124

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
